### PR TITLE
Feat: Filter Schedule by Session Dates

### DIFF
--- a/packages/app/app/[organization]/[event]/schedule/components/DateSelect.tsx
+++ b/packages/app/app/[organization]/[event]/schedule/components/DateSelect.tsx
@@ -14,7 +14,7 @@ const DateSelect = ({ dates }: { dates: number[] }) => {
 
   return (
     <Select
-      defaultValue={searchParams.get('date') || dates[0].toString()}
+      defaultValue={searchParams.get('date') || dates[0]?.toString()}
       onValueChange={(value) =>
         handleTermChange([
           {
@@ -32,6 +32,9 @@ const DateSelect = ({ dates }: { dates: number[] }) => {
             {new Date(dateNum).toDateString()}
           </SelectItem>
         ))}
+        {dates.length > 1 && (
+          <SelectItem value="all">All Dates</SelectItem>
+        )}
       </SelectContent>
     </Select>
   )

--- a/packages/app/app/[organization]/[event]/schedule/components/ScheduleCard.tsx
+++ b/packages/app/app/[organization]/[event]/schedule/components/ScheduleCard.tsx
@@ -20,11 +20,13 @@ const ScheduleCard = ({
   session,
   showTime = false,
   speakers = false,
+  date,
 }: {
   event: IExtendedEvent
   session: IExtendedSession
   showTime?: boolean
   speakers?: boolean
+  date?: string
 }) => {
   const isActive =
     new Date(session.start).getTime() < Date.now() &&
@@ -39,6 +41,8 @@ const ScheduleCard = ({
             <CardDescription className="text-secondary">
               {showTime && (
                 <>
+                  {date === 'all' &&
+                    new Date(session.start).toDateString()}{' '}
                   {moment(session.start)
                     .tz(event.timezone || 'UTC')
                     .format('HH:mm')}{' '}

--- a/packages/app/app/[organization]/[event]/schedule/components/ScheduleComponent.tsx
+++ b/packages/app/app/[organization]/[event]/schedule/components/ScheduleComponent.tsx
@@ -3,7 +3,7 @@ import DateSelect from './DateSelect'
 import SessionList from '@/components/sessions/SessionList'
 import { fetchAllSessions } from '@/lib/data'
 import { IStageModel } from 'streameth-new-server/src/interfaces/stage.interface'
-import { getEventDays } from '@/lib/utils/time'
+import { getEventDays, getSessionDays } from '@/lib/utils/time'
 import { isSameDay } from '@/lib/utils/time'
 import {
   Card,
@@ -24,24 +24,22 @@ const ScheduleComponent = async ({
   stage?: string
   date?: string
 }) => {
-  const dates = getEventDays(
-    new Date(event.start),
-    new Date(event.end)
-  )
-
   const sessionsData = await fetchAllSessions({
     event: event.slug,
     stageId: stage ?? stages[0]?.id,
   })
 
+  const dates = getSessionDays(sessionsData.sessions)
   const sessions = sessionsData.sessions.filter((session) => {
     if (date) {
+      if (date === 'all') return true
       return isSameDay(session.start, Number(date))
     }
-    return true
+    return isSameDay(session.start, Number(dates[0]))
   })
 
   if (!sessionsData.sessions.length) return null
+
   return (
     <Card
       id="schedule"
@@ -55,7 +53,11 @@ const ScheduleComponent = async ({
       </CardHeader>
       <CardContent className="p-3 lg:p-6">
         <div className="w-full flex flex-col relative">
-          <SessionList event={event} sessions={sessions} />
+          <SessionList
+            date={date}
+            event={event}
+            sessions={sessions}
+          />
         </div>
       </CardContent>
     </Card>

--- a/packages/app/components/sessions/SessionList.tsx
+++ b/packages/app/components/sessions/SessionList.tsx
@@ -7,6 +7,7 @@ interface Props {
   event: IExtendedEvent
   sessions: IExtendedSession[]
   currentSession?: IExtendedSession
+  date?: string
 }
 
 const scroll = Scroll.scroller
@@ -25,6 +26,7 @@ export default function SessionList({
   event,
   sessions,
   currentSession,
+  date,
 }: Props) {
   const getCurrDaySessions = () => {
     return sessions.filter(
@@ -77,6 +79,7 @@ export default function SessionList({
           <Element key={index} name={i._id}>
             <li id={i._id} className="mb-3 text-lg">
               <ScheduleCard
+                date={date}
                 event={event}
                 session={i}
                 showTime

--- a/packages/app/lib/utils/time.tsx
+++ b/packages/app/lib/utils/time.tsx
@@ -1,4 +1,5 @@
 import moment from 'moment-timezone'
+import { IExtendedSession } from '../types'
 
 export function generateTimezones() {
   const timezones = moment.tz.names()
@@ -83,4 +84,23 @@ export const isCurrentDateInUTC = (): number => {
 
 export const getDateInUTC = (date: Date): number => {
   return moment(date).utc().startOf('day').valueOf()
+}
+
+export const getSessionDays = (sessions: IExtendedSession[]) => {
+  // Create a Set to store unique dates
+  const uniqueDates = new Set()
+
+  // Iterate through sessions to extract and filter dates
+  sessions.forEach((session) => {
+    const sessionDate = new Date(session.start).toDateString()
+    uniqueDates.add(sessionDate)
+  })
+
+  // Convert Set to array and convert each date to timestamp
+  const uniqueDatesArray = Array.from(uniqueDates)
+  const uniqueTimestampsArray = uniqueDatesArray.map((dateString) =>
+    new Date(dateString as string).getTime()
+  )
+
+  return uniqueTimestampsArray
 }


### PR DESCRIPTION
This pull request addresses the issue with the schedule date filter on the event page. Previously, the date filter was based on the date range between the start and end of an event, which resulted in including days without sessions in the date filter. The updated approach uses session dates to determine the dates displayed in the filter, ensuring that only dates with sessions are included.

Additionally, the filter now supports filtering by all dates if multiple dates exist for an event. This enhancement allows users to filter events based on all available dates associated with the event.