### PR TITLE
Handle asset prefix on local 

### DIFF
--- a/packages/app/components/authorization/AuthorizationMessage.tsx
+++ b/packages/app/components/authorization/AuthorizationMessage.tsx
@@ -17,6 +17,7 @@ import { toast } from 'sonner'
 
 import Link from 'next/link'
 import SignInWithSocials from './SignInWithSocials'
+
 const AuthorizationMessage = () => {
   const { ready, authenticated, login } = usePrivy()
 

--- a/packages/app/components/misc/ConnectWalletButton.tsx
+++ b/packages/app/components/misc/ConnectWalletButton.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button'
 import { useLogin, useLogout, usePrivy } from '@privy-io/react-auth'
 import { deleteSession, storeSession } from '@/lib/actions/auth'
 import { apiUrl } from '@/lib/utils/utils'
+import { Loader2 } from 'lucide-react'
 
 interface ConnectWalletButtonProps {
   className?: string
@@ -13,7 +14,7 @@ export const ConnectWalletButton = ({
   btnText = 'Sign in',
   className,
 }: ConnectWalletButtonProps) => {
-  const { authenticated } = usePrivy()
+  const { ready, authenticated } = usePrivy()
 
   const getSession = async () => {
     const privyToken = localStorage.getItem('privy:token')
@@ -59,7 +60,13 @@ export const ConnectWalletButton = ({
     <Button
       onClick={authenticated ? logout : login}
       className={className}>
-      {authenticated ? 'Sign Out' : btnText}
+      {!ready ? (
+        <Loader2 className="mr-2 w-4 h-4 animate-spin" />
+      ) : authenticated ? (
+        'Sign Out'
+      ) : (
+        btnText
+      )}
     </Button>
   )
 }

--- a/packages/app/lib/utils/metadata.ts
+++ b/packages/app/lib/utils/metadata.ts
@@ -84,7 +84,7 @@ export const watchMetadata = ({
   organization,
   session,
 }: {
-  organization?: IExtendedOrganization
+  organization: IExtendedOrganization
   session: IExtendedSession
 }): Metadata => {
   const imageUrl = session?.coverImage
@@ -92,12 +92,12 @@ export const watchMetadata = ({
     : BASE_IMAGE
 
   return {
-    title: `${session.name} | ${organization?.name}`,
+    title: `${session.name} | ${organization.name}`,
     description: `${session.description}`,
     metadataBase: new URL('https://streameth.org'),
     openGraph: {
       title: `${session.name}`,
-      siteName: `${organization?.name}`,
+      siteName: `${organization.name}`,
       description: `${session.description}`,
       images: {
         url: session.coverImage ? session.coverImage : BASE_IMAGE,

--- a/packages/app/lib/utils/metadata.ts
+++ b/packages/app/lib/utils/metadata.ts
@@ -84,7 +84,7 @@ export const watchMetadata = ({
   organization,
   session,
 }: {
-  organization: IExtendedOrganization
+  organization?: IExtendedOrganization
   session: IExtendedSession
 }): Metadata => {
   const imageUrl = session?.coverImage
@@ -92,12 +92,12 @@ export const watchMetadata = ({
     : BASE_IMAGE
 
   return {
-    title: `${session.name} | ${organization.name}`,
+    title: `${session.name} | ${organization?.name}`,
     description: `${session.description}`,
     metadataBase: new URL('https://streameth.org'),
     openGraph: {
       title: `${session.name}`,
-      siteName: `${organization.name}`,
+      siteName: `${organization?.name}`,
       description: `${session.description}`,
       images: {
         url: session.coverImage ? session.coverImage : BASE_IMAGE,

--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -1,7 +1,8 @@
 const shouldAnalyzeBundles = process.env.ANALYZE === true
 /** @type {import('next').NextConfig} */
+const isProd = process.env.NODE_ENV === 'production'
 let nextConfig = {
-   assetPrefix: "https://streameth.org",
+  assetPrefix: isProd ? 'https://streameth.org' : undefined,
 
   redirects: async () => [
     {


### PR DESCRIPTION
This PR configures the manual CDN to use a custom asset prefix only in production and added minor optimization to auth