### PR TITLE
Fixed counter issue

### DIFF
--- a/packages/app/app/[organization]/livestream/components/Counter.tsx
+++ b/packages/app/app/[organization]/livestream/components/Counter.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 const CounterBox = ({
@@ -10,7 +11,7 @@ const CounterBox = ({
   lable: string
 }) => {
   return (
-    <div className="flex flex-col justify-between items-center p-1 md:p-2 text-black bg-white bg-opacity-70 rounded-lg">
+    <div className="flex flex-col justify-between items-center p-1 text-black bg-white bg-opacity-70 rounded-lg md:p-2">
       <div className="text-sm font-black md:text-4xl">{number}</div>
       <div className="text-xs md:text-xl">{lable}</div>
     </div>
@@ -22,6 +23,7 @@ const Counter = ({
 }: {
   timeToStart: number // time in milliseconds
 }) => {
+  const router = useRouter()
   const [time, setTime] = useState(timeToStart / 1000)
 
   useEffect(() => {
@@ -29,16 +31,20 @@ const Counter = ({
       setTime(time - 1)
     }, 1000)
 
+    if (time < 0) {
+      router.refresh()
+    }
+
     return () => clearInterval(interval)
   }, [time])
 
   return (
-    <div className="m-2 md:m-4 flex flex-col justify-between items-center md:p-0 backdrop-blur-sm backdrop-brightness-50 md:backdrop-brightness-100">
-      <div className="md:p-4 flex flex-col justify-center items-center w-full rounded-xl md:bg-black ">
-        <p className="text-md text-center text-white uppercase md:text-lg">
+    <div className="flex flex-col justify-between items-center m-2 md:p-0 md:m-4 backdrop-blur-sm backdrop-brightness-50 md:backdrop-brightness-100">
+      <div className="flex flex-col justify-center items-center w-full rounded-xl md:p-4 md:bg-black">
+        <p className="text-center text-white uppercase md:text-lg text-md">
           Stream will start in
         </p>
-        <div className="flex flex-wrap justify-center items-center m-2 space-x-2  md:space-y-0">
+        <div className="flex flex-wrap justify-center items-center m-2 space-x-2 md:space-y-0">
           <CounterBox
             lable="days"
             number={Math.floor(time / 86400)}

--- a/packages/app/app/[organization]/livestream/components/Player.tsx
+++ b/packages/app/app/[organization]/livestream/components/Player.tsx
@@ -1,4 +1,5 @@
 'use server'
+
 import { Livepeer } from 'livepeer'
 import { IExtendedStage } from '@/lib/types'
 import Counter from './Counter'
@@ -6,6 +7,7 @@ import { PlayerWithControls } from '@/components/ui/Player'
 import { buildPlaybackUrl } from '@/lib/utils/utils'
 import { notFound } from 'next/navigation'
 import Image from 'next/image'
+
 const Player = async ({ stage }: { stage: IExtendedStage }) => {
   const livepeer = new Livepeer({
     apiKey: process.env.LIVEPEER_API_KEY,
@@ -23,14 +25,13 @@ const Player = async ({ stage }: { stage: IExtendedStage }) => {
     new Date(stage.streamDate as string).getTime() - Date.now()
 
   // const prevChatMessages = await fetchChat({ stageId: stage?._id })
-  console.log(buildPlaybackUrl(stream.playbackId))
   return (
     <div className="flex flex-col w-full h-full">
       {timeLeft > 0 ? (
-        <div className="flex relative aspect-video rounded-xl w-full h-full items-end justify-end">
+        <div className="flex relative justify-end items-end w-full h-full rounded-xl aspect-video">
           {stage.thumbnail && (
             <Image
-              className="z-[0] lg:rounded-xl"
+              className="lg:rounded-xl z-[0]"
               fill={true}
               src={stage.thumbnail}
               alt="Livepeer Logo"

--- a/packages/app/app/studio/[organization]/library/components/DeleteAsset.tsx
+++ b/packages/app/app/studio/[organization]/library/components/DeleteAsset.tsx
@@ -37,7 +37,7 @@ const DeleteAsset = ({
     setLoading(false)
 
     if (href === 'refresh') {
-      location.reload()
+      router.refresh()
     }
     router.push(href)
   }

--- a/packages/app/app/studio/[organization]/library/components/UploadVideoDialog.tsx
+++ b/packages/app/app/studio/[organization]/library/components/UploadVideoDialog.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button'
 import UploadVideoForm from './upload/UploadVideoForm'
 import { useState } from 'react'
 import UploadComplete from '@/lib/svg/UploadComplete'
+import { useRouter } from 'next/navigation'
 
 const UploadVideoDialog = ({
   organizationId,
@@ -21,6 +22,7 @@ const UploadVideoDialog = ({
 }) => {
   const [open, setOpen] = useState(false)
   const [isUploaded, setIsUploaded] = useState(false)
+  const router = useRouter()
 
   const onFinish = () => {
     setIsUploaded(true)
@@ -57,7 +59,7 @@ const UploadVideoDialog = ({
             <Button
               variant={'secondary'}
               className="mx-auto w-1/3 border-2"
-              onClick={() => location.reload()}>
+              onClick={() => router.refresh()}>
               Go back to Assets
             </Button>
           </>


### PR DESCRIPTION
Bugfixes
- See #644
- Changed `location.reload` to `router.refresh`

> router.refresh(): Refresh the current route. Making a new request to the server, re-fetching data requests, and re-rendering Server Components. The client will merge the updated React Server Component payload without losing unaffected client-side React (e.g. useState) or browser state (e.g. scroll position).

