### PR TITLE
🩹 Putting back player controls to change video quality.

### DIFF
--- a/packages/app/app/studio/[organization]/clips/components/Player.tsx
+++ b/packages/app/app/studio/[organization]/clips/components/Player.tsx
@@ -105,7 +105,7 @@ const ReactHlsPlayer: React.FC<HlsPlayerProps> = ({
       <video
         ref={videoRef}
         autoPlay={false}
-        controls={false}
+        controls={true}
         className="sticky top-0 w-full rounded-lg"></video>
       <div className="absolute left-0 top-0 flex h-full w-full items-center justify-center">
         {isLoading && (


### PR DESCRIPTION
# Pull Request Info

## Description

Putting back player controls to change video quality so EthCC people can choose a lower video quality and don't run out of bandwidth.

Fixes ( Hotfix )

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if appropriate):

![CleanShot 2024-07-08 at 11 48 37@2x](https://github.com/streamethorg/streameth-platform/assets/36546318/cca0205d-508b-4a54-8bdf-e9f21f4a55d0)

## Additional context:

Just at least for EthCC people.
