### PR TITLE
🐛 Fix the sign-in flow getting stuck when quickly clicking sign-out

### DIFF
--- a/packages/app/components/misc/SignInUserButton.tsx
+++ b/packages/app/components/misc/SignInUserButton.tsx
@@ -69,7 +69,7 @@ export const SignInUserButton = ({
       className={className}
       disabled={!ready || isLoading}>
       {!ready || isLoading ? (
-        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        <Loader2 className="h-4 w-4 animate-spin" />
       ) : authenticated ? (
         'Sign Out'
       ) : (

--- a/packages/app/components/misc/SignInUserButton.tsx
+++ b/packages/app/components/misc/SignInUserButton.tsx
@@ -4,6 +4,7 @@ import { useLogin, useLogout, usePrivy } from '@privy-io/react-auth'
 import { deleteSession, storeSession } from '@/lib/actions/auth'
 import { apiUrl } from '@/lib/utils/utils'
 import { Loader2 } from 'lucide-react'
+import { useState } from 'react'
 
 interface SignInUserButtonProps {
   className?: string
@@ -15,6 +16,7 @@ export const SignInUserButton = ({
   className,
 }: SignInUserButtonProps) => {
   const { ready, authenticated } = usePrivy()
+  const [isLoading, setIsLoading] = useState(false)
 
   const getSession = async () => {
     const privyToken = localStorage.getItem('privy:token')
@@ -37,23 +39,36 @@ export const SignInUserButton = ({
   const { login } = useLogin({
     onComplete: () => {
       getSession()
+      setIsLoading(false)
     },
     onError: (error) => {
       deleteSession()
+      setIsLoading(false)
     },
   })
 
   const { logout } = useLogout({
     onSuccess: () => {
       deleteSession()
+      setIsLoading(false)
     },
   })
 
+  const handleClick = () => {
+    setIsLoading(true)
+    if (authenticated) {
+      logout()
+    } else {
+      login()
+    }
+  }
+
   return (
     <Button
-      onClick={authenticated ? logout : login}
-      className={className}>
-      {!ready ? (
+      onClick={handleClick}
+      className={className}
+      disabled={!ready || isLoading}>
+      {!ready || isLoading ? (
         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
       ) : authenticated ? (
         'Sign Out'


### PR DESCRIPTION
# 😵 Post-Mortem 😵

## Summary
When signing in, if you were to click in the sign-out button, the app wasn't able to properly handle the state and would get stuck.

## Impact
-    **Services Affected**: Sign in flow
-    **User Impact**: Could generate bad UX if user sees a completely frozen app

## Root Cause Analysis
No loading state handling from the front-end

## Resolution and Recovery
Properly handle the loading state + making the user actually sign-out if it clicks the sign-out button

## Lessons Learned
1. Whenever we need to have a loading state, properly use the `useState` hook

## Attachments
https://github.com/user-attachments/assets/13980207-10f9-4d66-9138-905ae7f2a0ba


## Related Issues

closes #637 

**Reviewer Checklist:**
-    [ ] Incident details are complete
-    [ ] Root cause is clearly defined
-    [ ] Resolution steps are clearly detailed
-    [ ] Related 🐛 issues are provided
