### PR TITLE
🐛: Reverted changes on the library page and added state logic to clipping page

### DIFF
--- a/packages/app/app/studio/[organization]/clips/components/CreateClipButton.tsx
+++ b/packages/app/app/studio/[organization]/clips/components/CreateClipButton.tsx
@@ -41,6 +41,11 @@ import {
   SelectGroup,
   SelectItem,
 } from '@/components/ui/select'
+import { createStateAction } from '@/lib/actions/state'
+import {
+  StateStatus,
+  StateType,
+} from 'streameth-new-server/src/interfaces/state.interface'
 
 const ClipButton = ({
   playbackId,
@@ -110,10 +115,20 @@ const ClipButton = ({
       end: endTime.unix,
       sessionId: session._id as string,
     })
-      .then(() => {
+      .then(async () => {
         setIsLoading(false)
         setSessionId('')
         setDialogOpen(false)
+
+        await createStateAction({
+          state: {
+            sessionId: session._id,
+            type: StateType.video,
+            sessionSlug: session.slug,
+            organizationId: session.organizationId,
+          },
+        })
+
         toast.success('Clip created')
       })
       .catch(() => {

--- a/packages/server/src/controllers/index.controller.ts
+++ b/packages/server/src/controllers/index.controller.ts
@@ -66,7 +66,7 @@ export class IndexController extends Controller {
         return SendApiResponse('Invalid signature or timestamp', null, '401');
       }
 
-      console.log(payload);
+      console.log('Livepeer Payload:', payload);
 
       switch (payload.event) {
         case LivepeerEvent.assetReady:

--- a/packages/server/src/interfaces/livepeer.interface.ts
+++ b/packages/server/src/interfaces/livepeer.interface.ts
@@ -1,5 +1,6 @@
 export enum LivepeerEvent {
   assetReady = 'asset.ready',
+  assetFailed = 'asset.failed',
   streamReady = 'stream.ready',
   streamIdle = 'stream.idle',
   streamStarted = 'stream.started',

--- a/packages/server/src/interfaces/state.interface.ts
+++ b/packages/server/src/interfaces/state.interface.ts
@@ -10,6 +10,7 @@ export enum StateStatus {
   completed = 'completed',
   canceled = 'canceled',
   sync = 'sync',
+  error = 'error',
 }
 
 export enum StateType {


### PR DESCRIPTION
# Pull Request Info

## Description

I reverted a few changes that were breaking the library. It now creates an `state` once the clip has been created. Showing it on the library page while processing.

I also added a untested webhook if the video has failed to process. We will have to wait until Livepeer fails to process once to examine the webhook.

Fixes (issue)
#769 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

