### PR TITLE
🐛 Fix #770

### DIFF
--- a/packages/app/app/studio/[organization]/Preview.tsx
+++ b/packages/app/app/studio/[organization]/Preview.tsx
@@ -72,7 +72,7 @@ const Preview = ({
             <div className="flex aspect-video flex-col items-center justify-center rounded-lg bg-background p-4 text-black">
               <p className="">Video is processing</p>
               <p>
-                {(Number(status?.progress?.toFixed(2)) ?? 0) * 100}%
+                {Math.round(Number(status?.progress ?? 0) * 100)}%
                 complete
               </p>
             </div>


### PR DESCRIPTION
## Description

We were already formatting `%` of clip completeness but I still encountered an issue, so I took another approach. Simply remove decimals

Fixes (#770)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/d651e84f-444c-438b-878e-ba47d891bf66

## Additional context:
The previous solution wasn't bad, but as I was unfortunate to find the same issue, I just decided to round to whole numbers and forget about decimals

closes #770 