### PR TITLE
🐛 Fixes #818

### DIFF
--- a/packages/app/components/misc/form/imageUpload.tsx
+++ b/packages/app/components/misc/form/imageUpload.tsx
@@ -52,7 +52,7 @@ const ConfirmImageDeletion: React.FC<ConfirmImageDeletionProps> = ({
           </Button>
           <Button
             onClick={() => {
-              onChange(null);
+              onChange('');
               setPreview('');
               setOpen(false);
             }}
@@ -71,8 +71,8 @@ interface ImageUploadProps {
   maxSize?: number;
   placeholder?: string;
   aspectRatio: number;
-  onChange: (files: string | null) => void;
-  value: string | null | undefined;
+  onChange: (value: string) => void;
+  value: string | undefined;
   path: string;
   className?: string;
   requireExactSize?: { width: number; height: number };
@@ -185,7 +185,13 @@ export default function ImageUpload({
         </div>
       ) : preview ? (
         <div className="relative h-full w-full">
-          <ConfirmImageDeletion onChange={onChange} setPreview={setPreview} />
+          <ConfirmImageDeletion
+            onChange={() => {
+              onChange('');
+              setPreview('');
+            }}
+            setPreview={setPreview}
+          />
           <Image src={preview} alt="preview" fill className={imageClasses} />
         </div>
       ) : (
@@ -207,25 +213,31 @@ export default function ImageUpload({
         placeholder="Upload image"
         className="hidden"
         onChange={(event: ChangeEvent<HTMLInputElement>) => {
-          const { files, displayUrl } = getImageData(event);
+          if (event.target.files && event.target.files.length > 0) {
+            const { files, displayUrl } = getImageData(event);
 
-          setPreview(displayUrl);
-          toast.promise(
-            onSubmit(files[0]).then((uploadedPath) => {
-              onChange(uploadedPath);
-              return 'Image uploaded successfully';
-            }),
-            {
-              loading: 'Uploading image',
-              success: (message) => {
-                return message;
-              },
-              error: (error: Error) => {
-                setPreview('');
-                return error.message || 'Unknown error';
-              },
-            }
-          );
+            setPreview(displayUrl);
+            toast.promise(
+              onSubmit(files[0]).then((uploadedPath) => {
+                onChange(uploadedPath);
+                return 'Image uploaded successfully';
+              }),
+              {
+                loading: 'Uploading image',
+                success: (message) => {
+                  return message;
+                },
+                error: (error: Error) => {
+                  setPreview('');
+                  onChange(''); // Set to empty string on error
+                  return error.message || 'Unknown error';
+                },
+              }
+            );
+          } else {
+            setPreview('');
+            onChange(''); // Set to empty string when no file is selected
+          }
         }}
       />
       {error && (


### PR DESCRIPTION
# Pull Request Info

## Description

In PR #814 I introduced a bug where when delting the banner and updating the organization, i was sending `null` instead of `' '` to the backend, and `null` is not supported on our organization schema (which makes total sense)

Fixes (#818)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/a0cf68c6-9426-4bdf-ae75-337f8fb52e46

## Additional context:

closes #818 
