### PR TITLE
🐛 Updated the thumbnail generation from .jpg to .png

### DIFF
--- a/packages/server/src/utils/livepeer.ts
+++ b/packages/server/src/utils/livepeer.ts
@@ -327,7 +327,7 @@ export const generateThumbnail = async (data: {
       ) ?? [];
 
     if (lpThumbnails.length > 0) {
-      return lpThumbnails[0].url.replace('thumbnails.vtt', 'keyframes_0.jpg');
+      return lpThumbnails[0].url.replace('thumbnails.vtt', 'keyframes_0.png');
     }
   } catch (e) {
     throw new HttpException(400, 'Error generating thumbnail');


### PR DESCRIPTION
# Pull Request Info

## Description

Livepeer updated their thumbnail generation without any notice. Luckily they simply changed from `jpg` to `png`

Fixes (not-tracked)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if appropriate):

![CleanShot 2024-08-12 at 19 29 15](https://github.com/user-attachments/assets/c4cec9e5-5c89-4f83-b126-cef7c0a9b78b)
