### PR TITLE
🐛 fix Long titles overflow modal on clip page and overflow text on organization description

### DIFF
--- a/packages/app/app/[organization]/components/ChannelDescription.tsx
+++ b/packages/app/app/[organization]/components/ChannelDescription.tsx
@@ -21,10 +21,10 @@ const ChannelDescription = ({ description }: { description?: string }) => {
   }, [contentRef]);
 
   return (
-    <div className="hidden w-4/5 md:block">
+    <div className="hidden w-4/5 md:block overflow-hidden">
       <div
         ref={contentRef}
-        className={!isExpanded ? 'line-clamp-2' : 'line-clamp-4'}
+        className={!isExpanded ? 'line-clamp-2 break-words' : 'line-clamp-4'}
       >
         {' '}
         {description}

--- a/packages/app/app/[organization]/page.tsx
+++ b/packages/app/app/[organization]/page.tsx
@@ -95,7 +95,7 @@ const OrganizationHome = async ({
             <div className="absolute left-0 top-0 h-full w-full bg-gradient-to-t from-black via-transparent to-transparent" />
             <div className="absolute bottom-0 left-0 right-0 w-full space-y-2 p-4 text-white">
               <div className="flex w-full flex-row justify-between">
-                <div>
+                <div className="overflow-hidden">
                   <h2 className="text-2xl font-bold">{organization.name}</h2>
                   <ChannelDescription description={organization.description} />
                 </div>

--- a/packages/app/app/studio/[organization]/clips/components/CreateClipButton.tsx
+++ b/packages/app/app/studio/[organization]/clips/components/CreateClipButton.tsx
@@ -143,7 +143,7 @@ const ClipButton = ({
   );
 
   return (
-    <div className="flex flex-grow flex-col space-y-2">
+    <div className="flex flex-grow flex-col space-y-2 overflow-hidden">
       <div className="my-4 flex flex-grow flex-col space-y-2">
         <Label>{custom ? 'Session name' : 'Select Session'}</Label>
         {custom ? (

--- a/packages/app/app/studio/[organization]/clips/components/CreateClipButton.tsx
+++ b/packages/app/app/studio/[organization]/clips/components/CreateClipButton.tsx
@@ -245,8 +245,8 @@ const CreateClipButton = ({
 
   return (
     <Dialog open={dialogOpen} onOpenChange={setIsOpen}>
-      <DialogContent className="bg-white">
-        <div className="flex h-[300px] flex-col bg-white p-4">
+      <DialogContent className="bg-white w-full sm:w-[500px]">
+        <div className="flex h-[300px] w-full sm:w-[460px]  flex-col bg-white p-4">
           <Tabs defaultValue={'sessions'}>
             <TabsList className="w-full !justify-start gap-5 border-y border-grey">
               {sessions.sessions.length > 0 && (

--- a/packages/app/app/studio/[organization]/library/[session]/page.tsx
+++ b/packages/app/app/studio/[organization]/library/[session]/page.tsx
@@ -79,7 +79,6 @@ const EditSession = async ({ params, searchParams }: studioPageParams) => {
               className="space-y-2"
               type="multiple"
               defaultValue={['publishVideo', 'menu']}
-
             >
               <AccordionItem defaultChecked value="menu">
                 <AccordionContent>

--- a/packages/app/components/ui/combo-box.tsx
+++ b/packages/app/components/ui/combo-box.tsx
@@ -63,8 +63,7 @@ export default function Combobox({
           className="w-full justify-between"
         >
           {logo && renderLogo(orgLogo)}
-          {value ? value : placeholder}
-
+          <p className="truncate ...">{value ? value : placeholder}</p>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>


### PR DESCRIPTION
# Pull Request Info

## Description

- Trucated Long titles overflow modal on clip page
- Break-words on Organization description overflows X-axis in banner

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if appropriate):

<img width="622" alt="image" src="https://github.com/user-attachments/assets/de9cf72f-ca89-4e90-9e18-3a760120fb83">

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/e0954cb2-0699-47bc-b072-053860127323">

closes #862 closes #875 closes #876