### PR TITLE
Feat/refetch assets

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@privy-io/server-auth": "^1.7.3",
+    "@pulsecron/pulse": "^1.6.3",
     "@thirdweb-dev/storage": "^2.0.10",
     "amqplib": "^0.10.4",
     "bcrypt": "^5.1.1",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,20 +1,21 @@
-import 'reflect-metadata';
+import { jobs } from '@utils/pulse.cron';
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
 import hpp from 'hpp';
+import createError from 'http-errors';
+import { connect, disconnect, set } from 'mongoose';
 import morgan from 'morgan';
-import { connect, set, disconnect } from 'mongoose';
+import 'reflect-metadata';
 import swaggerUi from 'swagger-ui-express';
 import { config } from './config';
-import errorMiddleware from './middlewares/error.middleware';
-import { logger } from './utils/logger';
 import { dbConnection } from './databases';
-import createError from 'http-errors';
-import * as swaggerDocument from './swagger/swagger.json';
+import errorMiddleware from './middlewares/error.middleware';
 import { RegisterRoutes } from './routes/routes';
+import * as swaggerDocument from './swagger/swagger.json';
+import { logger } from './utils/logger';
 
 class App {
   public app: express.Application;
@@ -30,6 +31,7 @@ class App {
     this.initializeMiddlewares();
     this.initializeSwagger();
     this.initializeErrorHandling();
+    this.initializeJobs();
   }
 
   listen() {
@@ -78,6 +80,10 @@ class App {
     this.app.use(express.urlencoded({ extended: true }));
     this.app.use(cookieParser());
     RegisterRoutes(this.app);
+  }
+
+  private initializeJobs() {
+    return jobs();
   }
 
   private initializeSwagger() {

--- a/packages/server/src/controllers/session.controller.ts
+++ b/packages/server/src/controllers/session.controller.ts
@@ -8,16 +8,16 @@ import { IStandardResponse, SendApiResponse } from '@utils/api.response';
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Path,
   Post,
   Put,
   Query,
   Route,
+  Security,
   SuccessResponse,
   Tags,
-  Security,
-  Delete,
 } from 'tsoa';
 
 @Tags('Session')
@@ -108,6 +108,7 @@ export class SessionController extends Controller {
   /**
    * @summary Transcribe session
    */
+  @Security('jwt', ['org'])
   @SuccessResponse('201')
   @Post('transcriptions')
   async sessionTranscriptions(
@@ -120,6 +121,7 @@ export class SessionController extends Controller {
   /**
    * @summary Publish session to socials
    */
+  @Security('jwt', ['org'])
   @SuccessResponse('201')
   @Post('upload')
   async uploadSessionToSocials(

--- a/packages/server/src/interfaces/session.interface.ts
+++ b/packages/server/src/interfaces/session.interface.ts
@@ -61,6 +61,14 @@ export interface ISession {
   firebaseId?: string;
   talkType?: string;
   clippingStatus?: ClippingStatus;
+  transcripts?: {
+    subtitleUrl: string;
+    chunks: {
+      timestamp: number[];
+      text: string;
+    }[];
+    text: string;
+  };
 }
 
 export interface ISessionModel extends Omit<ISession, '_id'>, Document {}

--- a/packages/server/src/models/session.model.ts
+++ b/packages/server/src/models/session.model.ts
@@ -64,6 +64,16 @@ const SessionSchema = new Schema<ISessionModel>(
     firebaseId: { type: String, default: '' },
     talkType: { type: String, default: '' },
     clippingStatus: { type: String, enum: Object.keys(ClippingStatus) },
+    transcripts: {
+      subtitleUrl: { type: String, default: '' },
+      chunks: [
+        {
+          text: { type: String, default: '' },
+          tiimestamp: [{ type: Number }],
+        },
+      ],
+      text: { type: String, default: '' },
+    },
     createdAt: { type: Date, default: Date.now },
   },
   {

--- a/packages/server/src/swagger/swagger.json
+++ b/packages/server/src/swagger/swagger.json
@@ -1,5701 +1,6189 @@
 {
-  "openapi": "3.0.0",
-  "components": {
-    "examples": {},
-    "headers": {},
-    "parameters": {},
-    "requestBodies": {},
-    "responses": {},
-    "schemas": {
-      "mongoose.Types.ObjectId": {
-        "type": "string"
-      },
-      "ISocials": {
-        "properties": {
-          "_id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "accessToken": {
-            "type": "string"
-          },
-          "refreshToken": {
-            "type": "string"
-          },
-          "expireTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "name": {
-            "type": "string"
-          },
-          "thumbnail": {
-            "type": "string"
-          },
-          "channelId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "accessToken",
-          "refreshToken",
-          "expireTime",
-          "name"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IOrganization": {
-        "properties": {
-          "_id": {
-            "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-          },
-          "name": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "bio": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          },
-          "logo": {
-            "type": "string"
-          },
-          "location": {
-            "type": "string"
-          },
-          "accentColor": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "banner": {
-            "type": "string"
-          },
-          "walletAddress": {
-            "type": "string"
-          },
-          "address": {
-            "type": "string"
-          },
-          "socials": {
-            "items": {
-              "$ref": "#/components/schemas/ISocials"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["name", "email", "logo"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "UserRole": {
-        "enum": ["user", "admin"],
-        "type": "string"
-      },
-      "IUser": {
-        "properties": {
-          "walletAddress": {
-            "type": "string"
-          },
-          "organizations": {
-            "items": {
-              "$ref": "#/components/schemas/IOrganization"
-            },
-            "type": "array"
-          },
-          "role": {
-            "$ref": "#/components/schemas/UserRole"
-          },
-          "token": {
-            "type": "string"
-          },
-          "did": {
-            "type": "string"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_IUser_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/IUser"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "ISupport": {
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "telegram": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "image": {
-            "type": "string"
-          }
-        },
-        "required": ["message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_ISupport_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/ISupport"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateSupportTicketDto": {
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "telegram": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "image": {
-            "type": "string"
-          }
-        },
-        "required": ["message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_ISupport-Array_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ISupport"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_any_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {}
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateMultiStreamDto": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "streamId": {
-            "type": "string"
-          },
-          "targetStreamKey": {
-            "type": "string"
-          },
-          "targetURL": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "socialId": {
-            "type": "string"
-          },
-          "socialType": {
-            "type": "string"
-          },
-          "broadcastId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "streamId",
-          "targetStreamKey",
-          "targetURL",
-          "organizationId"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_void_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {}
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "DeleteMultiStreamDto": {
-        "properties": {
-          "streamId": {
-            "type": "string"
-          },
-          "targetId": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          }
-        },
-        "required": ["streamId", "targetId", "organizationId"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse__url-string--assetId-string__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "properties": {
-              "assetId": {
-                "type": "string"
-              },
-              "url": {
-                "type": "string"
-              }
-            },
-            "required": ["assetId", "url"],
-            "type": "object"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_string_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "type": "string"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse__playbackUrl-string--phaseStatus-string__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "properties": {
-              "phaseStatus": {
-                "type": "string"
-              },
-              "playbackUrl": {
-                "type": "string"
-              }
-            },
-            "required": ["phaseStatus", "playbackUrl"],
-            "type": "object"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse__viewCount-number--playTimeMins-number__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "properties": {
-              "playTimeMins": {
-                "type": "number",
-                "format": "double"
-              },
-              "viewCount": {
-                "type": "number",
-                "format": "double"
-              }
-            },
-            "required": ["playTimeMins", "viewCount"],
-            "type": "object"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateClipDto": {
-        "properties": {
-          "playbackId": {
-            "type": "string"
-          },
-          "sessionId": {
-            "type": "string"
-          },
-          "recordingId": {
-            "type": "string"
-          },
-          "start": {
-            "type": "number",
-            "format": "double"
-          },
-          "end": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "required": ["playbackId", "sessionId", "recordingId", "start", "end"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "SheetType": {
-        "enum": ["gsheet", "pretalx"],
-        "type": "string"
-      },
-      "StateStatus": {
-        "enum": ["pending", "completed", "canceled", "sync", "failed"],
-        "type": "string"
-      },
-      "StateType": {
-        "enum": ["nft", "event", "video"],
-        "type": "string"
-      },
-      "IState": {
-        "properties": {
-          "_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "eventId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "sessionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "eventSlug": {
-            "type": "string"
-          },
-          "sessionSlug": {
-            "type": "string"
-          },
-          "sheetType": {
-            "$ref": "#/components/schemas/SheetType"
-          },
-          "status": {
-            "$ref": "#/components/schemas/StateStatus"
-          },
-          "type": {
-            "$ref": "#/components/schemas/StateType"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_IState_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/IState"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateStateDto": {
-        "properties": {
-          "_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "eventId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "sessionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "eventSlug": {
-            "type": "string"
-          },
-          "sessionSlug": {
-            "type": "string"
-          },
-          "sheetType": {
-            "$ref": "#/components/schemas/SheetType"
-          },
-          "status": {
-            "$ref": "#/components/schemas/StateStatus"
-          },
-          "type": {
-            "$ref": "#/components/schemas/StateType"
-          }
-        },
-        "required": ["organizationId"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "UpdateStateDto": {
-        "properties": {
-          "eventId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "sessionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "eventSlug": {
-            "type": "string"
-          },
-          "sessionSlug": {
-            "type": "string"
-          },
-          "sheetType": {
-            "$ref": "#/components/schemas/SheetType"
-          },
-          "status": {
-            "$ref": "#/components/schemas/StateStatus"
-          },
-          "type": {
-            "$ref": "#/components/schemas/StateType"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_Array_IState__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/IState"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "TargetOutput": {
-        "properties": {
-          "_id": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "socialId": {
-            "type": "string"
-          },
-          "socialType": {
-            "type": "string"
-          },
-          "broadcastId": {
-            "type": "string"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStreamSettings": {
-        "properties": {
-          "streamId": {
-            "type": "string"
-          },
-          "parentId": {
-            "type": "string"
-          },
-          "playbackId": {
-            "type": "string"
-          },
-          "isHealthy": {
-            "type": "boolean"
-          },
-          "isActive": {
-            "type": "boolean"
-          },
-          "streamKey": {
-            "type": "string"
-          },
-          "ipfshash": {
-            "type": "string"
-          },
-          "targets": {
-            "items": {
-              "$ref": "#/components/schemas/TargetOutput"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IPlugin": {
-        "properties": {
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": ["name"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStage": {
-        "properties": {
-          "_id": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "eventId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "streamSettings": {
-            "$ref": "#/components/schemas/IStreamSettings"
-          },
-          "plugins": {
-            "items": {
-              "$ref": "#/components/schemas/IPlugin"
-            },
-            "type": "array"
-          },
-          "order": {
-            "type": "number",
-            "format": "double"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "published": {
-            "type": "boolean"
-          },
-          "isMultipleDate": {
-            "type": "boolean"
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "thumbnail": {
-            "type": "string"
-          },
-          "streamDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "streamEndDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "mintable": {
-            "type": "boolean"
-          },
-          "createdAt": {
-            "type": "string"
-          },
-          "nftCollections": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ]
-          },
-          "recordingIndex": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "required": ["name", "organizationId"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_IStage_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/IStage"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateStageDto": {
-        "properties": {
-          "_id": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "eventId": {
-            "type": "string"
-          },
-          "streamSettings": {
-            "$ref": "#/components/schemas/IStreamSettings"
-          },
-          "plugins": {
-            "items": {
-              "$ref": "#/components/schemas/IPlugin"
-            },
-            "type": "array"
-          },
-          "order": {
-            "type": "number",
-            "format": "double"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "published": {
-            "type": "boolean"
-          },
-          "isMultipleDate": {
-            "type": "boolean"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "thumbnail": {
-            "type": "string"
-          },
-          "streamDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "streamEndDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "mintable": {
-            "type": "boolean"
-          },
-          "createdAt": {
-            "type": "string"
-          },
-          "nftCollections": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ]
-          },
-          "recordingIndex": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "required": ["name", "organizationId"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "UpdateStageDto": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "eventId": {
-            "type": "string"
-          },
-          "published": {
-            "type": "boolean"
-          },
-          "isMultipleDate": {
-            "type": "boolean"
-          },
-          "streamSettings": {
-            "$ref": "#/components/schemas/IStreamSettings"
-          },
-          "plugins": {
-            "items": {
-              "$ref": "#/components/schemas/IPlugin"
-            },
-            "type": "array"
-          },
-          "order": {
-            "type": "number",
-            "format": "double"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "streamDate": {
-            "type": "string"
-          },
-          "streamEndDate": {
-            "type": "string"
-          },
-          "thumbnail": {
-            "type": "string"
-          },
-          "mintable": {
-            "type": "boolean"
-          },
-          "nftCollections": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ]
-          }
-        },
-        "required": ["name", "organizationId"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_Array_IStage__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/IStage"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "OrgIdDto": {
-        "properties": {
-          "organizationId": {
-            "type": "string"
-          }
-        },
-        "required": ["organizationId"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse__streamKey-string--ingestUrl-string__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "properties": {
-              "ingestUrl": {
-                "type": "string"
-              },
-              "streamKey": {
-                "type": "string"
-              }
-            },
-            "required": ["ingestUrl", "streamKey"],
-            "type": "object"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateLiveStreamDto": {
-        "properties": {
-          "stageId": {
-            "type": "string"
-          },
-          "socialId": {
-            "type": "string"
-          },
-          "socialType": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          }
-        },
-        "required": ["stageId", "socialId", "socialType", "organizationId"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "ISpeaker": {
-        "properties": {
-          "_id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "bio": {
-            "type": "string"
-          },
-          "eventId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "twitter": {
-            "type": "string"
-          },
-          "github": {
-            "type": "string"
-          },
-          "website": {
-            "type": "string"
-          },
-          "photo": {
-            "type": "string"
-          },
-          "company": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          }
-        },
-        "required": ["name", "bio", "organizationId"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_ISpeaker_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/ISpeaker"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateSpeakerDto": {
-        "properties": {
-          "_id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "bio": {
-            "type": "string"
-          },
-          "eventId": {
-            "type": "string"
-          },
-          "twitter": {
-            "type": "string"
-          },
-          "github": {
-            "type": "string"
-          },
-          "website": {
-            "type": "string"
-          },
-          "photo": {
-            "type": "string"
-          },
-          "company": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          }
-        },
-        "required": ["name", "bio", "organizationId", "eventId"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_Array_ISpeaker__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ISpeaker"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "Pick_ISpeaker.Exclude_keyofISpeaker.organizationId__": {
-        "properties": {
-          "_id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "bio": {
-            "type": "string"
-          },
-          "eventId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "twitter": {
-            "type": "string"
-          },
-          "github": {
-            "type": "string"
-          },
-          "website": {
-            "type": "string"
-          },
-          "photo": {
-            "type": "string"
-          },
-          "company": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          }
-        },
-        "required": ["name", "bio"],
-        "type": "object",
-        "description": "From T, pick a set of properties whose keys are in the union K"
-      },
-      "Omit_ISpeaker.organizationId_": {
-        "$ref": "#/components/schemas/Pick_ISpeaker.Exclude_keyofISpeaker.organizationId__",
-        "description": "Construct a type with the properties of T except for those in type K."
-      },
-      "ISource": {
-        "properties": {
-          "streamUrl": {
-            "type": "string"
-          },
-          "start": {
-            "type": "number",
-            "format": "double"
-          },
-          "end": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IPlayback": {
-        "properties": {
-          "livepeerId": {
-            "type": "string"
-          },
-          "videoUrl": {
-            "type": "string"
-          },
-          "ipfsHash": {
-            "type": "string"
-          },
-          "format": {
-            "type": "string"
-          },
-          "duration": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "SessionType": {
-        "enum": ["clip", "livestream", "video"],
-        "type": "string"
-      },
-      "ClippingStatus": {
-        "enum": ["pending", "failed", "completed"],
-        "type": "string"
-      },
-      "ISession": {
-        "properties": {
-          "_id": {
-            "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "start": {
-            "type": "number",
-            "format": "double"
-          },
-          "end": {
-            "type": "number",
-            "format": "double"
-          },
-          "startClipTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "endClipTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "stageId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "speakers": {
-            "items": {
-              "$ref": "#/components/schemas/Omit_ISpeaker.organizationId_"
-            },
-            "type": "array"
-          },
-          "source": {
-            "$ref": "#/components/schemas/ISource"
-          },
-          "assetId": {
-            "type": "string"
-          },
-          "playback": {
-            "$ref": "#/components/schemas/IPlayback"
-          },
-          "videoUrl": {
-            "type": "string"
-          },
-          "playbackId": {
-            "type": "string"
-          },
-          "eventId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "track": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "coverImage": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "eventSlug": {
-            "type": "string"
-          },
-          "videoTranscription": {
-            "type": "string"
-          },
-          "aiDescription": {
-            "type": "string"
-          },
-          "autoLabels": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "ipfsURI": {
-            "type": "string"
-          },
-          "mintable": {
-            "type": "boolean"
-          },
-          "published": {
-            "type": "boolean"
-          },
-          "type": {
-            "$ref": "#/components/schemas/SessionType"
-          },
-          "createdAt": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "nftCollections": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ]
-          },
-          "socials": {
-            "items": {
-              "properties": {
-                "date": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": ["date", "name"],
-              "type": "object"
-            },
-            "type": "array"
-          },
-          "firebaseId": {
-            "type": "string"
-          },
-          "talkType": {
-            "type": "string"
-          },
-          "clippingStatus": {
-            "$ref": "#/components/schemas/ClippingStatus"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "start",
-          "end",
-          "organizationId",
-          "type"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_ISession_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/ISession"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "Pick_ISession.Exclude_keyofISession._id__": {
-        "properties": {
-          "organizationId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "eventId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "slug": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "start": {
-            "type": "number",
-            "format": "double"
-          },
-          "end": {
-            "type": "number",
-            "format": "double"
-          },
-          "startClipTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "endClipTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "stageId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "speakers": {
-            "items": {
-              "$ref": "#/components/schemas/Omit_ISpeaker.organizationId_"
-            },
-            "type": "array"
-          },
-          "source": {
-            "$ref": "#/components/schemas/ISource"
-          },
-          "assetId": {
-            "type": "string"
-          },
-          "playback": {
-            "$ref": "#/components/schemas/IPlayback"
-          },
-          "videoUrl": {
-            "type": "string"
-          },
-          "playbackId": {
-            "type": "string"
-          },
-          "track": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "coverImage": {
-            "type": "string"
-          },
-          "eventSlug": {
-            "type": "string"
-          },
-          "videoTranscription": {
-            "type": "string"
-          },
-          "aiDescription": {
-            "type": "string"
-          },
-          "autoLabels": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "ipfsURI": {
-            "type": "string"
-          },
-          "mintable": {
-            "type": "boolean"
-          },
-          "published": {
-            "type": "boolean"
-          },
-          "type": {
-            "$ref": "#/components/schemas/SessionType"
-          },
-          "createdAt": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ]
-          },
-          "nftCollections": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ]
-          },
-          "socials": {
-            "items": {
-              "properties": {
-                "date": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": ["date", "name"],
-              "type": "object"
-            },
-            "type": "array"
-          },
-          "firebaseId": {
-            "type": "string"
-          },
-          "talkType": {
-            "type": "string"
-          },
-          "clippingStatus": {
-            "$ref": "#/components/schemas/ClippingStatus"
-          }
-        },
-        "required": [
-          "organizationId",
-          "name",
-          "description",
-          "start",
-          "end",
-          "type"
-        ],
-        "type": "object",
-        "description": "From T, pick a set of properties whose keys are in the union K"
-      },
-      "CreateSessionDto": {
-        "properties": {
-          "organizationId": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "eventId": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "start": {
-            "type": "number",
-            "format": "double"
-          },
-          "end": {
-            "type": "number",
-            "format": "double"
-          },
-          "startClipTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "endClipTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "stageId": {
-            "type": "string"
-          },
-          "speakers": {
-            "items": {
-              "$ref": "#/components/schemas/ISpeaker"
-            },
-            "type": "array"
-          },
-          "source": {
-            "$ref": "#/components/schemas/ISource"
-          },
-          "assetId": {
-            "type": "string"
-          },
-          "playback": {
-            "$ref": "#/components/schemas/IPlayback"
-          },
-          "videoUrl": {
-            "type": "string"
-          },
-          "playbackId": {
-            "type": "string"
-          },
-          "track": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "coverImage": {
-            "type": "string"
-          },
-          "eventSlug": {
-            "type": "string"
-          },
-          "videoTranscription": {
-            "type": "string"
-          },
-          "aiDescription": {
-            "type": "string"
-          },
-          "autoLabels": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "ipfsURI": {
-            "type": "string"
-          },
-          "mintable": {
-            "type": "boolean"
-          },
-          "published": {
-            "type": "boolean"
-          },
-          "type": {
-            "$ref": "#/components/schemas/SessionType"
-          },
-          "createdAt": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ]
-          },
-          "nftCollections": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ]
-          },
-          "socials": {
-            "items": {
-              "properties": {
-                "date": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": ["date", "name"],
-              "type": "object"
-            },
-            "type": "array"
-          },
-          "firebaseId": {
-            "type": "string"
-          },
-          "talkType": {
-            "type": "string"
-          },
-          "clippingStatus": {
-            "$ref": "#/components/schemas/ClippingStatus"
-          },
-          "autolabels": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "organizationId",
-          "name",
-          "description",
-          "start",
-          "end",
-          "type",
-          "speakers"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "UpdateSessionDto": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "start": {
-            "type": "number",
-            "format": "double"
-          },
-          "end": {
-            "type": "number",
-            "format": "double"
-          },
-          "startClipTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "endClipTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "stageId": {
-            "type": "string"
-          },
-          "speakers": {
-            "items": {
-              "$ref": "#/components/schemas/Omit_ISpeaker.organizationId_"
-            },
-            "type": "array"
-          },
-          "source": {
-            "$ref": "#/components/schemas/ISource"
-          },
-          "playback": {
-            "$ref": "#/components/schemas/IPlayback"
-          },
-          "videoUrl": {
-            "type": "string"
-          },
-          "playbackId": {
-            "type": "string"
-          },
-          "eventId": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "track": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "coverImage": {
-            "type": "string"
-          },
-          "eventSlug": {
-            "type": "string"
-          },
-          "videoTranscription": {
-            "type": "string"
-          },
-          "aiDescription": {
-            "type": "string"
-          },
-          "autolabels": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "assetId": {
-            "type": "string"
-          },
-          "ipfsURI": {
-            "type": "string"
-          },
-          "published": {
-            "type": "boolean"
-          },
-          "type": {
-            "$ref": "#/components/schemas/SessionType"
-          },
-          "nftURI": {
-            "type": "string"
-          },
-          "mintable": {
-            "type": "boolean"
-          },
-          "nftCollections": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ]
-          },
-          "active": {
-            "type": "boolean"
-          },
-          "socials": {
-            "items": {
-              "properties": {
-                "date": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": ["date", "name"],
-              "type": "object"
-            },
-            "type": "array"
-          },
-          "createdAt": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "start",
-          "end",
-          "speakers",
-          "organizationId",
-          "type"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_Array_ISession__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ISession"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "Pick_UploadSessionDto.organizationId-or-sessionId_": {
-        "properties": {
-          "organizationId": {
-            "type": "string"
-          },
-          "sessionId": {
-            "type": "string"
-          }
-        },
-        "required": ["sessionId"],
-        "type": "object",
-        "description": "From T, pick a set of properties whose keys are in the union K"
-      },
-      "UploadSessionDto": {
-        "properties": {
-          "socialId": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "sessionId": {
-            "type": "string"
-          },
-          "token": {
-            "properties": {
-              "secret": {
-                "type": "string"
-              },
-              "key": {
-                "type": "string"
-              }
-            },
-            "required": ["secret"],
-            "type": "object"
-          },
-          "type": {
-            "type": "string"
-          },
-          "text": {
-            "type": "string"
-          },
-          "refreshToken": {
-            "type": "string"
-          }
-        },
-        "required": ["sessionId", "type"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse__sessions-Array_ISession_--totalDocuments-number--pageable_58__page-number--size-number___": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "properties": {
-              "pageable": {
-                "properties": {
-                  "size": {
-                    "type": "number",
-                    "format": "double"
-                  },
-                  "page": {
-                    "type": "number",
-                    "format": "double"
-                  }
-                },
-                "required": ["size", "page"],
-                "type": "object"
-              },
-              "totalDocuments": {
-                "type": "number",
-                "format": "double"
-              },
-              "sessions": {
-                "items": {
-                  "$ref": "#/components/schemas/ISession"
-                },
-                "type": "array"
-              }
-            },
-            "required": ["pageable", "totalDocuments", "sessions"],
-            "type": "object"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "ImportType": {
-        "enum": ["gsheet", "pretalx"],
-        "type": "string"
-      },
-      "Pick_IScheduleImporterDto.url-or-type-or-organizationId_": {
-        "properties": {
-          "organizationId": {
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/ImportType"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "required": ["organizationId", "type", "url"],
-        "type": "object",
-        "description": "From T, pick a set of properties whose keys are in the union K"
-      },
-      "Pick_IScheduleImporterDto.url-or-type-or-organizationId-or-stageId_": {
-        "properties": {
-          "organizationId": {
-            "type": "string"
-          },
-          "stageId": {
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/ImportType"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "required": ["organizationId", "stageId", "type", "url"],
-        "type": "object",
-        "description": "From T, pick a set of properties whose keys are in the union K"
-      },
-      "IStandardResponse_IOrganization_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/IOrganization"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "Pick_IOrganization.Exclude_keyofIOrganization._id__": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "bio": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "socials": {
-            "items": {
-              "$ref": "#/components/schemas/ISocials"
-            },
-            "type": "array"
-          },
-          "url": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "logo": {
-            "type": "string"
-          },
-          "location": {
-            "type": "string"
-          },
-          "accentColor": {
-            "type": "string"
-          },
-          "banner": {
-            "type": "string"
-          },
-          "walletAddress": {
-            "type": "string"
-          },
-          "address": {
-            "type": "string"
-          }
-        },
-        "required": ["name", "email", "logo"],
-        "type": "object",
-        "description": "From T, pick a set of properties whose keys are in the union K"
-      },
-      "CreateOrganizationDto": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "bio": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "socials": {
-            "items": {
-              "$ref": "#/components/schemas/ISocials"
-            },
-            "type": "array"
-          },
-          "url": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "logo": {
-            "type": "string"
-          },
-          "location": {
-            "type": "string"
-          },
-          "accentColor": {
-            "type": "string"
-          },
-          "banner": {
-            "type": "string"
-          },
-          "walletAddress": {
-            "type": "string"
-          },
-          "address": {
-            "type": "string"
-          }
-        },
-        "required": ["name", "email", "logo", "walletAddress"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "UpdateOrganizationDto": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "logo": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "walletAddress": {
-            "type": "string"
-          },
-          "banner": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "required": ["name", "logo", "email", "walletAddress"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "Pick_CreateOrganizationDto.address_": {
-        "properties": {
-          "address": {
-            "type": "string"
-          }
-        },
-        "type": "object",
-        "description": "From T, pick a set of properties whose keys are in the union K"
-      },
-      "IStandardResponse_Array_IOrganization__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/IOrganization"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_Array_IUser__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/IUser"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "Pick_CreateOrganizationDto.walletAddress_": {
-        "properties": {
-          "walletAddress": {
-            "type": "string"
-          }
-        },
-        "required": ["walletAddress"],
-        "type": "object",
-        "description": "From T, pick a set of properties whose keys are in the union K"
-      },
-      "NftCollectionType": {
-        "enum": ["single", "multiple"],
-        "type": "string"
-      },
-      "INftCollection": {
-        "properties": {
-          "_id": {
-            "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "thumbnail": {
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/NftCollectionType"
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "videos": {
-            "items": {
-              "properties": {
-                "ipfsURI": {
-                  "type": "string"
-                },
-                "stageId": {
-                  "type": "string"
-                },
-                "sessionId": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "index": {
-                  "type": "number",
-                  "format": "double"
-                }
-              },
-              "required": ["type"],
-              "type": "object"
-            },
-            "type": "array"
-          },
-          "contractAddress": {
-            "type": "string"
-          },
-          "ipfsPath": {
-            "type": "string"
-          }
-        },
-        "required": ["name"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_INftCollection_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/INftCollection"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateNftCollectionDto": {
-        "properties": {
-          "_id": {
-            "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "thumbnail": {
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/NftCollectionType"
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "videos": {
-            "items": {
-              "properties": {
-                "ipfsURI": {
-                  "type": "string"
-                },
-                "stageId": {
-                  "type": "string"
-                },
-                "sessionId": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "index": {
-                  "type": "number",
-                  "format": "double"
-                }
-              },
-              "required": ["ipfsURI", "type", "index"],
-              "type": "object"
-            },
-            "type": "array"
-          },
-          "contractAddress": {
-            "type": "string"
-          },
-          "ipfsPath": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "thumbnail",
-          "type",
-          "organizationId",
-          "videos"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse__ipfsPath-string--videos-Array_any___": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "properties": {
-              "videos": {
-                "items": {},
-                "type": "array"
-              },
-              "ipfsPath": {
-                "type": "string"
-              }
-            },
-            "required": ["videos", "ipfsPath"],
-            "type": "object"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "UpdateNftCollectionDto": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "thumbnail": {
-            "type": "string"
-          },
-          "contractAddress": {
-            "type": "string"
-          },
-          "ipfsPath": {
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/NftCollectionType"
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              }
-            ]
-          },
-          "videos": {
-            "items": {
-              "properties": {
-                "ipfsURI": {
-                  "type": "string"
-                },
-                "stageId": {
-                  "type": "string"
-                },
-                "sessionId": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "index": {
-                  "type": "number",
-                  "format": "double"
-                }
-              },
-              "required": ["type"],
-              "type": "object"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["name"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_Array_INftCollection__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/INftCollection"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "GSheetConfig": {
-        "properties": {
-          "sheetId": {
-            "type": "string"
-          },
-          "apiKey": {
-            "type": "string"
-          },
-          "driveId": {
-            "type": "string"
-          },
-          "driveApiKey": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "PretalxConfig": {
-        "properties": {
-          "url": {
-            "type": "string"
-          },
-          "apiToken": {
-            "type": "string"
-          },
-          "sheetId": {
-            "type": "string"
-          }
-        },
-        "required": ["apiToken"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IDataImporter": {
-        "anyOf": [
-          {
-            "properties": {
-              "config": {
-                "$ref": "#/components/schemas/GSheetConfig"
-              },
-              "type": {
-                "type": "string",
-                "enum": ["gsheet"],
-                "nullable": false
-              }
-            },
-            "required": ["config", "type"],
-            "type": "object"
-          },
-          {
-            "properties": {
-              "config": {
-                "$ref": "#/components/schemas/PretalxConfig"
-              },
-              "type": {
-                "type": "string",
-                "enum": ["pretalx"],
-                "nullable": false
-              }
-            },
-            "required": ["config", "type"],
-            "type": "object"
-          }
-        ]
-      },
-      "IDataExporter": {
-        "properties": {
-          "config": {
-            "$ref": "#/components/schemas/GSheetConfig"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["gdrive"],
-            "nullable": false
-          }
-        },
-        "required": ["config", "type"],
-        "type": "object"
-      },
-      "IPlugins": {
-        "properties": {
-          "disableChat": {
-            "type": "boolean"
-          },
-          "hideSchedule": {
-            "type": "boolean"
-          }
-        },
-        "required": ["disableChat"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IEventNFT": {
-        "properties": {
-          "address": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "symbol": {
-            "type": "string"
-          },
-          "uri": {
-            "type": "string"
-          },
-          "maxSupply": {
-            "type": "string"
-          },
-          "mintFee": {
-            "type": "string"
-          },
-          "startTime": {
-            "type": "string"
-          },
-          "endTime": {
-            "type": "string"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IEvent": {
-        "properties": {
-          "_id": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "start": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "end": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "location": {
-            "type": "string"
-          },
-          "logo": {
-            "type": "string"
-          },
-          "banner": {
-            "type": "string"
-          },
-          "startTime": {
-            "type": "string"
-          },
-          "endTime": {
-            "type": "string"
-          },
-          "organizationId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "dataImporter": {
-            "items": {
-              "$ref": "#/components/schemas/IDataImporter"
-            },
-            "type": "array"
-          },
-          "eventCover": {
-            "type": "string"
-          },
-          "archiveMode": {
-            "type": "boolean"
-          },
-          "website": {
-            "type": "string"
-          },
-          "timezone": {
-            "type": "string"
-          },
-          "accentColor": {
-            "type": "string"
-          },
-          "unlisted": {
-            "type": "boolean"
-          },
-          "dataExporter": {
-            "items": {
-              "$ref": "#/components/schemas/IDataExporter"
-            },
-            "type": "array"
-          },
-          "enableVideoDownloader": {
-            "type": "boolean"
-          },
-          "plugins": {
-            "$ref": "#/components/schemas/IPlugins"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "eventNFT": {
-            "$ref": "#/components/schemas/IEventNFT"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "start",
-          "end",
-          "location",
-          "organizationId",
-          "timezone"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_IEvent_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/IEvent"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateEventDto": {
-        "properties": {
-          "_id": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "start": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "end": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "location": {
-            "type": "string"
-          },
-          "logo": {
-            "type": "string"
-          },
-          "banner": {
-            "type": "string"
-          },
-          "startTime": {
-            "type": "string"
-          },
-          "endTime": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "dataImporter": {
-            "items": {
-              "$ref": "#/components/schemas/IDataImporter"
-            },
-            "type": "array"
-          },
-          "eventCover": {
-            "type": "string"
-          },
-          "archiveMode": {
-            "type": "boolean"
-          },
-          "website": {
-            "type": "string"
-          },
-          "timezone": {
-            "type": "string"
-          },
-          "accentColor": {
-            "type": "string"
-          },
-          "unlisted": {
-            "type": "boolean"
-          },
-          "dataExporter": {
-            "items": {
-              "$ref": "#/components/schemas/IDataExporter"
-            },
-            "type": "array"
-          },
-          "enableVideoDownloader": {
-            "type": "boolean"
-          },
-          "plugins": {
-            "$ref": "#/components/schemas/IPlugins"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "eventNFT": {
-            "$ref": "#/components/schemas/IEventNFT"
-          },
-          "nftAddress": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "start",
-          "end",
-          "location",
-          "organizationId",
-          "timezone",
-          "logo",
-          "banner"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "UpdateEventDto": {
-        "properties": {
-          "_id": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "start": {
-            "type": "string"
-          },
-          "end": {
-            "type": "string"
-          },
-          "location": {
-            "type": "string"
-          },
-          "logo": {
-            "type": "string"
-          },
-          "banner": {
-            "type": "string"
-          },
-          "startTime": {
-            "type": "string"
-          },
-          "endTime": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "dataImporter": {
-            "items": {
-              "$ref": "#/components/schemas/IDataImporter"
-            },
-            "type": "array"
-          },
-          "eventCover": {
-            "type": "string"
-          },
-          "archiveMode": {
-            "type": "boolean"
-          },
-          "website": {
-            "type": "string"
-          },
-          "timezone": {
-            "type": "string"
-          },
-          "accentColor": {
-            "type": "string"
-          },
-          "unlisted": {
-            "type": "boolean"
-          },
-          "dataExporter": {
-            "items": {
-              "$ref": "#/components/schemas/IDataExporter"
-            },
-            "type": "array"
-          },
-          "enableVideoDownloader": {
-            "type": "boolean"
-          },
-          "plugins": {
-            "$ref": "#/components/schemas/IPlugins"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "eventNFT": {
-            "$ref": "#/components/schemas/IEventNFT"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "start",
-          "end",
-          "location",
-          "organizationId",
-          "timezone",
-          "logo",
-          "banner"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_Array_IEvent__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/IEvent"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IFrom": {
-        "properties": {
-          "identity": {
-            "type": "string"
-          }
-        },
-        "required": ["identity"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IChat": {
-        "properties": {
-          "stageId": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/mongoose.Types.ObjectId"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "message": {
-            "type": "string"
-          },
-          "from": {
-            "$ref": "#/components/schemas/IFrom"
-          },
-          "timestamp": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "required": ["stageId", "message", "from", "timestamp"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_IChat_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/IChat"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "CreateChatDto": {
-        "properties": {
-          "stageId": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "from": {
-            "$ref": "#/components/schemas/IFrom"
-          },
-          "timestamp": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "required": ["stageId", "message", "from", "timestamp"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_IChat-Array_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/IChat"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse__user-IUser--token-string__": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "properties": {
-              "token": {
-                "type": "string"
-              },
-              "user": {
-                "$ref": "#/components/schemas/IUser"
-              }
-            },
-            "required": ["token", "user"],
-            "type": "object"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "UserDto": {
-        "properties": {
-          "token": {
-            "type": "string"
-          }
-        },
-        "required": ["token"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "IStandardResponse_boolean_": {
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "type": "boolean"
-          }
-        },
-        "required": ["status", "message"],
-        "type": "object",
-        "additionalProperties": false
-      }
-    },
-    "securitySchemes": {
-      "jwt": {
-        "name": "Authorization",
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT",
-        "in": "header"
-      }
-    }
-  },
-  "info": {
-    "title": "streameth-api",
-    "version": "3.0.0",
-    "contact": {}
-  },
-  "paths": {
-    "/users/{walletAddress}": {
-      "get": {
-        "operationId": "GetUserById",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IUser_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["User"],
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "walletAddress",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/Tickets": {
-      "post": {
-        "operationId": "CreateTicket",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_ISupport_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Creates support ticket",
-        "tags": ["Support"],
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateSupportTicketDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetAllTickets",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_ISupport-Array_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get all support tickets",
-        "tags": ["Support"],
-        "security": [],
-        "parameters": []
-      }
-    },
-    "/streams/multistream": {
-      "post": {
-        "operationId": "CreateMultiStream",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_any_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Create Multistream",
-        "tags": ["Stream"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateMultiStreamDto"
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "operationId": "DeleteMultiStream",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Delete Multistream",
-        "tags": ["Stream"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DeleteMultiStreamDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/streams/asset": {
-      "post": {
-        "operationId": "CreateAsset",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse__url-string--assetId-string__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Create stream asset",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          }
-        }
-      }
-    },
-    "/streams/{streamId}": {
-      "get": {
-        "operationId": "GetStream",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_any_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get Stream",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "streamId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/streams/asset/{assetId}": {
-      "get": {
-        "operationId": "GetAsset",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_any_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get Asset",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "assetId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/streams/asset/url/{assetId}": {
-      "get": {
-        "operationId": "GetVideoUrl",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_string_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get Video url",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "assetId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/streams/asset/phase-action/{assetId}": {
-      "get": {
-        "operationId": "GetPhaseAction",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse__playbackUrl-string--phaseStatus-string__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get Video Phase Action",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "assetId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/streams/metric/{playbackId}": {
-      "get": {
-        "operationId": "GetSessionMetrics",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse__viewCount-number--playTimeMins-number__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get stream metrics",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "playbackId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/streams/recording/{streamId}": {
-      "get": {
-        "operationId": "GetStreamRecordings",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_any_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get stream recordings",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "streamId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/streams/upload/{assetId}": {
-      "get": {
-        "operationId": "UploadToIpfs",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_string_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Upload",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "assetId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/streams/clip": {
-      "post": {
-        "operationId": "CreateClip",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_any_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Create clip",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateClipDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/streams/thumbnail/generate": {
-      "post": {
-        "operationId": "GenerateThumbnail",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_any_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Generate thumbnail",
-        "tags": ["Stream"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          }
-        }
-      }
-    },
-    "/states": {
-      "post": {
-        "operationId": "CreateState",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IState_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["State"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateStateDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetAllStates",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_IState__"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["State"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "eventId",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "sessionId",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "eventSlug",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "type",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/states/{stateId}": {
-      "put": {
-        "operationId": "UpdateState",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IState_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["State"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "stateId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateStateDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/stages": {
-      "post": {
-        "operationId": "CreateStage",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IStage_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Create Session",
-        "tags": ["Stage"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateStageDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetAllStages",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_IStage__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get All Stage",
-        "tags": ["Stage"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "published",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ]
-      }
-    },
-    "/stages/{stageId}": {
-      "put": {
-        "operationId": "EditStage",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IStage_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Update Stage",
-        "tags": ["Stage"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "stageId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateStageDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetStageById",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IStage_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get Stage by id",
-        "tags": ["Stage"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "stageId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      },
-      "delete": {
-        "operationId": "DeleteStage",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Delete Stage",
-        "tags": ["Stage"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "stageId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrgIdDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/stages/event/{eventId}": {
-      "get": {
-        "operationId": "GetAllStagesForEvent",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_IStage__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get All Stage for Event",
-        "tags": ["Stage"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "eventId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/stages/organization/{organizationId}": {
-      "get": {
-        "operationId": "GetAllStagesForOrganization",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_IStage__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get All Stage for Organization",
-        "tags": ["Stage"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/stages/livestream": {
-      "post": {
-        "operationId": "YoutubeStage",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse__streamKey-string--ingestUrl-string__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Create Livestream on youtube & twitter",
-        "tags": ["Stage"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateLiveStreamDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/speakers": {
-      "post": {
-        "operationId": "CreateSpeaker",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_ISpeaker_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Speaker"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateSpeakerDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/speakers/{speakerId}": {
-      "get": {
-        "operationId": "GetSpeaker",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_ISpeaker_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Speaker"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "speakerId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/speakers/event/{eventId}": {
-      "get": {
-        "operationId": "GetAllSpeakersForEvent",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_ISpeaker__"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Speaker"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "eventId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/sessions": {
-      "post": {
-        "operationId": "CreateSession",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_ISession_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Create Session",
-        "tags": ["Session"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateSessionDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetAllSessions",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse__sessions-Array_ISession_--totalDocuments-number--pageable_58__page-number--size-number___"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get All Session",
-        "tags": ["Session"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "event",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "organization",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "speaker",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "stageId",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "onlyVideos",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "format": "double",
-              "type": "number"
-            }
-          },
-          {
-            "in": "query",
-            "name": "size",
-            "required": false,
-            "schema": {
-              "format": "double",
-              "type": "number"
-            }
-          },
-          {
-            "in": "query",
-            "name": "timestamp",
-            "required": false,
-            "schema": {
-              "format": "double",
-              "type": "number"
-            }
-          },
-          {
-            "in": "query",
-            "name": "assetId",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "published",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "type",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/sessions/{sessionId}": {
-      "put": {
-        "operationId": "EditSession",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_ISession_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Update Session",
-        "tags": ["Session"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "sessionId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateSessionDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetSessionById",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_ISession_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Fetch session by id",
-        "tags": ["Session"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "sessionId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      },
-      "delete": {
-        "operationId": "DeleteSession",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Delete Session",
-        "tags": ["Session"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "sessionId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrgIdDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sessions/organization/{organizationId}": {
-      "get": {
-        "operationId": "GetOrgEventSessions",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_ISession__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get all event sessions",
-        "tags": ["Session"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/sessions/search": {
-      "get": {
-        "operationId": "FilterSession",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_ISession__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Search sessions",
-        "tags": ["Session"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "search",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/sessions/{organizationSlug}/search": {
-      "get": {
-        "operationId": "FilterSessionByOrganisation",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_ISession__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Search sessions per organisation",
-        "tags": ["Session"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationSlug",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "search",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/sessions/transcriptions": {
-      "post": {
-        "operationId": "SessionTranscriptions",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Transcribe session",
-        "tags": ["Session"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Pick_UploadSessionDto.organizationId-or-sessionId_"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sessions/upload": {
-      "post": {
-        "operationId": "UploadSessionToSocials",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Publish session to socials",
-        "tags": ["Session"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UploadSessionDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/schedule/import": {
-      "post": {
-        "operationId": "ImportSchdeule",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Schedule"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Pick_IScheduleImporterDto.url-or-type-or-organizationId_"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/schedule/import/stage": {
-      "post": {
-        "operationId": "ImportSchdeuleByStage",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Schedule"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Pick_IScheduleImporterDto.url-or-type-or-organizationId-or-stageId_"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/schedule/import/save": {
-      "post": {
-        "operationId": "Save",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Schedule"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "scheduleId": {
-                    "type": "string"
-                  }
-                },
-                "required": ["scheduleId"],
-                "type": "object"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/organizations": {
-      "post": {
-        "operationId": "CreateOrganization",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IOrganization_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Create organization",
-        "tags": ["Organization"],
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateOrganizationDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetAllOrganizations",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_IOrganization__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get all organizations",
-        "tags": ["Organization"],
-        "security": [],
-        "parameters": []
-      }
-    },
-    "/organizations/{organizationId}": {
-      "put": {
-        "operationId": "EditOrganization",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IOrganization_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Update organization",
-        "tags": ["Organization"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateOrganizationDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetOrganizationById",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IOrganization_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get organization by",
-        "tags": ["Organization"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      },
-      "delete": {
-        "operationId": "DeleteOrganization",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Delete organization",
-        "tags": ["Organization"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/organizations/member/{organizationId}": {
-      "put": {
-        "operationId": "UpdateOrgMembers",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Add member to organization",
-        "tags": ["Organization"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Pick_CreateOrganizationDto.address_"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetAllOrgMembers",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_IUser__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get all organization members",
-        "tags": ["Organization"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      },
-      "delete": {
-        "operationId": "DeleteOrgMember",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Delete organization member",
-        "tags": ["Organization"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Pick_CreateOrganizationDto.walletAddress_"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/organizations/socials/{organizationId}": {
-      "put": {
-        "operationId": "UpdateOrgSocials",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Add socials to organization",
-        "tags": ["Organization"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ISocials"
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "operationId": "DeleteOrgSocial",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Delete organization social",
-        "tags": ["Organization"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "destinationId": {
-                    "type": "string"
-                  }
-                },
-                "required": ["destinationId"],
-                "type": "object"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections": {
-      "post": {
-        "operationId": "CreateNftCollection",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_INftCollection_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Create nft collection",
-        "tags": ["Collections"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateNftCollectionDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetAllCollections",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_INftCollection__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get all nft collections",
-        "tags": ["Collections"],
-        "security": [],
-        "parameters": []
-      }
-    },
-    "/collections/metadata/generate": {
-      "post": {
-        "operationId": "GenerateNftMetadata",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse__ipfsPath-string--videos-Array_any___"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Generate nft metadata",
-        "tags": ["Collections"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateNftCollectionDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collectionId}": {
-      "put": {
-        "operationId": "UpdateNftCollection",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_INftCollection_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Update nft collection",
-        "tags": ["Collections"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "collectionId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateNftCollectionDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetNftCollectionById",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_INftCollection_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get Nft collection by id",
-        "tags": ["Collections"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "collectionId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/collections/organization/{organizationId}": {
-      "get": {
-        "operationId": "GetAllOrganizationNft",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_INftCollection__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get Nft collections by organization",
-        "tags": ["Collections"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organizationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/": {
-      "get": {
-        "operationId": "Index",
-        "responses": {
-          "200": {
-            "description": "Ok",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_string_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Index"],
-        "security": [],
-        "parameters": []
-      }
-    },
-    "/upload": {
-      "post": {
-        "operationId": "UploadImges",
-        "responses": {
-          "200": {
-            "description": "Ok",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_string_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Index"],
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary"
-                  },
-                  "directory": {
-                    "type": "string"
-                  }
-                },
-                "required": ["file", "directory"]
-              }
-            }
-          }
-        }
-      }
-    },
-    "/webhook": {
-      "post": {
-        "operationId": "Webhook",
-        "responses": {
-          "200": {
-            "description": "Ok",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_string_"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Index"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "header",
-            "name": "livepeer-signature",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          }
-        }
-      }
-    },
-    "/events": {
-      "post": {
-        "operationId": "CreateEvent",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IEvent_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Creates Event",
-        "tags": ["Event"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateEventDto"
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "GetAllEvents",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_Array_IEvent__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get All Event",
-        "tags": ["Event"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "organizationId",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "unlisted",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ]
-      }
-    },
-    "/events/{eventId}": {
-      "get": {
-        "operationId": "GetEventById",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IEvent_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get Event",
-        "tags": ["Event"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "eventId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      },
-      "put": {
-        "operationId": "EditEvent",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IEvent_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Update Event",
-        "tags": ["Event"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "eventId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateEventDto"
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "operationId": "DeleteEvent",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Delete Event",
-        "tags": ["Event"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "eventId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrgIdDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/events/import/{eventId}": {
-      "put": {
-        "operationId": "EvenImporter",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_void_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Event importer",
-        "tags": ["Event"],
-        "security": [
-          {
-            "jwt": ["org"]
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "eventId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrgIdDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/chats": {
-      "post": {
-        "operationId": "CreateCHar",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IChat_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Creates Chat",
-        "tags": ["Chat"],
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateChatDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/chats/{stageId}": {
-      "get": {
-        "operationId": "GetChatStageById",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_IChat-Array_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get all chats by stage",
-        "tags": ["Chat"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "stageId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/auth/login": {
-      "post": {
-        "operationId": "Login",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse__user-IUser--token-string__"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Login",
-        "tags": ["Auth"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserDto"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/auth/verify-token": {
-      "post": {
-        "operationId": "VerifyToken",
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IStandardResponse_boolean_"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Verify auth token",
-        "tags": ["Auth"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserDto"
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "servers": [
-    {
-      "url": "/streameth-platform-packages-new2"
-    }
-  ]
+	"openapi": "3.0.0",
+	"components": {
+		"examples": {},
+		"headers": {},
+		"parameters": {},
+		"requestBodies": {},
+		"responses": {},
+		"schemas": {
+			"mongoose.Types.ObjectId": {
+				"type": "string"
+			},
+			"ISocials": {
+				"properties": {
+					"_id": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					},
+					"accessToken": {
+						"type": "string"
+					},
+					"refreshToken": {
+						"type": "string"
+					},
+					"expireTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"name": {
+						"type": "string"
+					},
+					"thumbnail": {
+						"type": "string"
+					},
+					"channelId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type",
+					"accessToken",
+					"refreshToken",
+					"expireTime",
+					"name"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IOrganization": {
+				"properties": {
+					"_id": {
+						"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+					},
+					"name": {
+						"type": "string"
+					},
+					"email": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"bio": {
+						"type": "string"
+					},
+					"url": {
+						"type": "string"
+					},
+					"logo": {
+						"type": "string"
+					},
+					"location": {
+						"type": "string"
+					},
+					"accentColor": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"banner": {
+						"type": "string"
+					},
+					"walletAddress": {
+						"type": "string"
+					},
+					"address": {
+						"type": "string"
+					},
+					"socials": {
+						"items": {
+							"$ref": "#/components/schemas/ISocials"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"name",
+					"email",
+					"logo"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UserRole": {
+				"enum": [
+					"user",
+					"admin"
+				],
+				"type": "string"
+			},
+			"IUser": {
+				"properties": {
+					"walletAddress": {
+						"type": "string"
+					},
+					"organizations": {
+						"items": {
+							"$ref": "#/components/schemas/IOrganization"
+						},
+						"type": "array"
+					},
+					"role": {
+						"$ref": "#/components/schemas/UserRole"
+					},
+					"token": {
+						"type": "string"
+					},
+					"did": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_IUser_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/IUser"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ISupport": {
+				"properties": {
+					"message": {
+						"type": "string"
+					},
+					"telegram": {
+						"type": "string"
+					},
+					"email": {
+						"type": "string"
+					},
+					"image": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_ISupport_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/ISupport"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateSupportTicketDto": {
+				"properties": {
+					"message": {
+						"type": "string"
+					},
+					"telegram": {
+						"type": "string"
+					},
+					"email": {
+						"type": "string"
+					},
+					"image": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_ISupport-Array_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/ISupport"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_any_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateMultiStreamDto": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"streamId": {
+						"type": "string"
+					},
+					"targetStreamKey": {
+						"type": "string"
+					},
+					"targetURL": {
+						"type": "string"
+					},
+					"organizationId": {
+						"type": "string"
+					},
+					"socialId": {
+						"type": "string"
+					},
+					"socialType": {
+						"type": "string"
+					},
+					"broadcastId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"streamId",
+					"targetStreamKey",
+					"targetURL",
+					"organizationId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_void_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"DeleteMultiStreamDto": {
+				"properties": {
+					"streamId": {
+						"type": "string"
+					},
+					"targetId": {
+						"type": "string"
+					},
+					"organizationId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"streamId",
+					"targetId",
+					"organizationId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse__url-string--assetId-string__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"properties": {
+							"assetId": {
+								"type": "string"
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"assetId",
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_string_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse__playbackUrl-string--phaseStatus-string__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"properties": {
+							"phaseStatus": {
+								"type": "string"
+							},
+							"playbackUrl": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"phaseStatus",
+							"playbackUrl"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse__viewCount-number--playTimeMins-number__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"properties": {
+							"playTimeMins": {
+								"type": "number",
+								"format": "double"
+							},
+							"viewCount": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"playTimeMins",
+							"viewCount"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateClipDto": {
+				"properties": {
+					"playbackId": {
+						"type": "string"
+					},
+					"sessionId": {
+						"type": "string"
+					},
+					"recordingId": {
+						"type": "string"
+					},
+					"start": {
+						"type": "number",
+						"format": "double"
+					},
+					"end": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"playbackId",
+					"sessionId",
+					"recordingId",
+					"start",
+					"end"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"SheetType": {
+				"enum": [
+					"gsheet",
+					"pretalx"
+				],
+				"type": "string"
+			},
+			"StateStatus": {
+				"enum": [
+					"pending",
+					"completed",
+					"canceled",
+					"sync",
+					"failed"
+				],
+				"type": "string"
+			},
+			"StateType": {
+				"enum": [
+					"nft",
+					"event",
+					"video"
+				],
+				"type": "string"
+			},
+			"IState": {
+				"properties": {
+					"_id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"eventId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"sessionId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"eventSlug": {
+						"type": "string"
+					},
+					"sessionSlug": {
+						"type": "string"
+					},
+					"sheetType": {
+						"$ref": "#/components/schemas/SheetType"
+					},
+					"status": {
+						"$ref": "#/components/schemas/StateStatus"
+					},
+					"type": {
+						"$ref": "#/components/schemas/StateType"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_IState_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/IState"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateStateDto": {
+				"properties": {
+					"_id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"eventId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"sessionId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"eventSlug": {
+						"type": "string"
+					},
+					"sessionSlug": {
+						"type": "string"
+					},
+					"sheetType": {
+						"$ref": "#/components/schemas/SheetType"
+					},
+					"status": {
+						"$ref": "#/components/schemas/StateStatus"
+					},
+					"type": {
+						"$ref": "#/components/schemas/StateType"
+					}
+				},
+				"required": [
+					"organizationId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UpdateStateDto": {
+				"properties": {
+					"eventId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"sessionId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"eventSlug": {
+						"type": "string"
+					},
+					"sessionSlug": {
+						"type": "string"
+					},
+					"sheetType": {
+						"$ref": "#/components/schemas/SheetType"
+					},
+					"status": {
+						"$ref": "#/components/schemas/StateStatus"
+					},
+					"type": {
+						"$ref": "#/components/schemas/StateType"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_Array_IState__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/IState"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TargetOutput": {
+				"properties": {
+					"_id": {
+						"type": "string"
+					},
+					"id": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"socialId": {
+						"type": "string"
+					},
+					"socialType": {
+						"type": "string"
+					},
+					"broadcastId": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStreamSettings": {
+				"properties": {
+					"streamId": {
+						"type": "string"
+					},
+					"parentId": {
+						"type": "string"
+					},
+					"playbackId": {
+						"type": "string"
+					},
+					"isHealthy": {
+						"type": "boolean"
+					},
+					"isActive": {
+						"type": "boolean"
+					},
+					"streamKey": {
+						"type": "string"
+					},
+					"ipfshash": {
+						"type": "string"
+					},
+					"targets": {
+						"items": {
+							"$ref": "#/components/schemas/TargetOutput"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IPlugin": {
+				"properties": {
+					"name": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStage": {
+				"properties": {
+					"_id": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"eventId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"streamSettings": {
+						"$ref": "#/components/schemas/IStreamSettings"
+					},
+					"plugins": {
+						"items": {
+							"$ref": "#/components/schemas/IPlugin"
+						},
+						"type": "array"
+					},
+					"order": {
+						"type": "number",
+						"format": "double"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"published": {
+						"type": "boolean"
+					},
+					"isMultipleDate": {
+						"type": "boolean"
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"thumbnail": {
+						"type": "string"
+					},
+					"streamDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"streamEndDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"mintable": {
+						"type": "boolean"
+					},
+					"createdAt": {
+						"type": "string"
+					},
+					"nftCollections": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"recordingIndex": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"name",
+					"organizationId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_IStage_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/IStage"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateStageDto": {
+				"properties": {
+					"_id": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"eventId": {
+						"type": "string"
+					},
+					"streamSettings": {
+						"$ref": "#/components/schemas/IStreamSettings"
+					},
+					"plugins": {
+						"items": {
+							"$ref": "#/components/schemas/IPlugin"
+						},
+						"type": "array"
+					},
+					"order": {
+						"type": "number",
+						"format": "double"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"published": {
+						"type": "boolean"
+					},
+					"isMultipleDate": {
+						"type": "boolean"
+					},
+					"organizationId": {
+						"type": "string"
+					},
+					"thumbnail": {
+						"type": "string"
+					},
+					"streamDate": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"streamEndDate": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"mintable": {
+						"type": "boolean"
+					},
+					"createdAt": {
+						"type": "string"
+					},
+					"nftCollections": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"recordingIndex": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"name",
+					"organizationId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UpdateStageDto": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"eventId": {
+						"type": "string"
+					},
+					"published": {
+						"type": "boolean"
+					},
+					"isMultipleDate": {
+						"type": "boolean"
+					},
+					"streamSettings": {
+						"$ref": "#/components/schemas/IStreamSettings"
+					},
+					"plugins": {
+						"items": {
+							"$ref": "#/components/schemas/IPlugin"
+						},
+						"type": "array"
+					},
+					"order": {
+						"type": "number",
+						"format": "double"
+					},
+					"organizationId": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"streamDate": {
+						"type": "string"
+					},
+					"streamEndDate": {
+						"type": "string"
+					},
+					"thumbnail": {
+						"type": "string"
+					},
+					"mintable": {
+						"type": "boolean"
+					},
+					"nftCollections": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					}
+				},
+				"required": [
+					"name",
+					"organizationId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_Array_IStage__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/IStage"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"OrgIdDto": {
+				"properties": {
+					"organizationId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"organizationId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse__streamKey-string--ingestUrl-string__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"properties": {
+							"ingestUrl": {
+								"type": "string"
+							},
+							"streamKey": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"ingestUrl",
+							"streamKey"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateLiveStreamDto": {
+				"properties": {
+					"stageId": {
+						"type": "string"
+					},
+					"socialId": {
+						"type": "string"
+					},
+					"socialType": {
+						"type": "string"
+					},
+					"organizationId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"stageId",
+					"socialId",
+					"socialType",
+					"organizationId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ISpeaker": {
+				"properties": {
+					"_id": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"bio": {
+						"type": "string"
+					},
+					"eventId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"twitter": {
+						"type": "string"
+					},
+					"github": {
+						"type": "string"
+					},
+					"website": {
+						"type": "string"
+					},
+					"photo": {
+						"type": "string"
+					},
+					"company": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					}
+				},
+				"required": [
+					"name",
+					"bio",
+					"organizationId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_ISpeaker_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/ISpeaker"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateSpeakerDto": {
+				"properties": {
+					"_id": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"bio": {
+						"type": "string"
+					},
+					"eventId": {
+						"type": "string"
+					},
+					"twitter": {
+						"type": "string"
+					},
+					"github": {
+						"type": "string"
+					},
+					"website": {
+						"type": "string"
+					},
+					"photo": {
+						"type": "string"
+					},
+					"company": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"organizationId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"bio",
+					"organizationId",
+					"eventId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_Array_ISpeaker__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/ISpeaker"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Pick_ISpeaker.Exclude_keyofISpeaker.organizationId__": {
+				"properties": {
+					"_id": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"bio": {
+						"type": "string"
+					},
+					"eventId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"twitter": {
+						"type": "string"
+					},
+					"github": {
+						"type": "string"
+					},
+					"website": {
+						"type": "string"
+					},
+					"photo": {
+						"type": "string"
+					},
+					"company": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"bio"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_ISpeaker.organizationId_": {
+				"$ref": "#/components/schemas/Pick_ISpeaker.Exclude_keyofISpeaker.organizationId__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"ISource": {
+				"properties": {
+					"streamUrl": {
+						"type": "string"
+					},
+					"start": {
+						"type": "number",
+						"format": "double"
+					},
+					"end": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IPlayback": {
+				"properties": {
+					"livepeerId": {
+						"type": "string"
+					},
+					"videoUrl": {
+						"type": "string"
+					},
+					"ipfsHash": {
+						"type": "string"
+					},
+					"format": {
+						"type": "string"
+					},
+					"duration": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"SessionType": {
+				"enum": [
+					"clip",
+					"livestream",
+					"video"
+				],
+				"type": "string"
+			},
+			"ClippingStatus": {
+				"enum": [
+					"pending",
+					"failed",
+					"completed"
+				],
+				"type": "string"
+			},
+			"ISession": {
+				"properties": {
+					"_id": {
+						"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+					},
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"start": {
+						"type": "number",
+						"format": "double"
+					},
+					"end": {
+						"type": "number",
+						"format": "double"
+					},
+					"startClipTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"endClipTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"stageId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"speakers": {
+						"items": {
+							"$ref": "#/components/schemas/Omit_ISpeaker.organizationId_"
+						},
+						"type": "array"
+					},
+					"source": {
+						"$ref": "#/components/schemas/ISource"
+					},
+					"assetId": {
+						"type": "string"
+					},
+					"playback": {
+						"$ref": "#/components/schemas/IPlayback"
+					},
+					"videoUrl": {
+						"type": "string"
+					},
+					"playbackId": {
+						"type": "string"
+					},
+					"eventId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"track": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"coverImage": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"eventSlug": {
+						"type": "string"
+					},
+					"videoTranscription": {
+						"type": "string"
+					},
+					"aiDescription": {
+						"type": "string"
+					},
+					"autoLabels": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"ipfsURI": {
+						"type": "string"
+					},
+					"mintable": {
+						"type": "boolean"
+					},
+					"published": {
+						"type": "boolean"
+					},
+					"type": {
+						"$ref": "#/components/schemas/SessionType"
+					},
+					"createdAt": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"nftCollections": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"socials": {
+						"items": {
+							"properties": {
+								"date": {
+									"type": "number",
+									"format": "double"
+								},
+								"name": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"date",
+								"name"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"firebaseId": {
+						"type": "string"
+					},
+					"talkType": {
+						"type": "string"
+					},
+					"clippingStatus": {
+						"$ref": "#/components/schemas/ClippingStatus"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"start",
+					"end",
+					"organizationId",
+					"type"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_ISession_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/ISession"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Pick_ISession.Exclude_keyofISession._id__": {
+				"properties": {
+					"organizationId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"name": {
+						"type": "string"
+					},
+					"eventId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"slug": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"start": {
+						"type": "number",
+						"format": "double"
+					},
+					"end": {
+						"type": "number",
+						"format": "double"
+					},
+					"startClipTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"endClipTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"stageId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"speakers": {
+						"items": {
+							"$ref": "#/components/schemas/Omit_ISpeaker.organizationId_"
+						},
+						"type": "array"
+					},
+					"source": {
+						"$ref": "#/components/schemas/ISource"
+					},
+					"assetId": {
+						"type": "string"
+					},
+					"playback": {
+						"$ref": "#/components/schemas/IPlayback"
+					},
+					"videoUrl": {
+						"type": "string"
+					},
+					"playbackId": {
+						"type": "string"
+					},
+					"track": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"coverImage": {
+						"type": "string"
+					},
+					"eventSlug": {
+						"type": "string"
+					},
+					"videoTranscription": {
+						"type": "string"
+					},
+					"aiDescription": {
+						"type": "string"
+					},
+					"autoLabels": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"ipfsURI": {
+						"type": "string"
+					},
+					"mintable": {
+						"type": "boolean"
+					},
+					"published": {
+						"type": "boolean"
+					},
+					"type": {
+						"$ref": "#/components/schemas/SessionType"
+					},
+					"createdAt": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "string",
+								"format": "date-time"
+							}
+						]
+					},
+					"nftCollections": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"socials": {
+						"items": {
+							"properties": {
+								"date": {
+									"type": "number",
+									"format": "double"
+								},
+								"name": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"date",
+								"name"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"firebaseId": {
+						"type": "string"
+					},
+					"talkType": {
+						"type": "string"
+					},
+					"clippingStatus": {
+						"$ref": "#/components/schemas/ClippingStatus"
+					}
+				},
+				"required": [
+					"organizationId",
+					"name",
+					"description",
+					"start",
+					"end",
+					"type"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"CreateSessionDto": {
+				"properties": {
+					"organizationId": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"eventId": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"start": {
+						"type": "number",
+						"format": "double"
+					},
+					"end": {
+						"type": "number",
+						"format": "double"
+					},
+					"startClipTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"endClipTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"stageId": {
+						"type": "string"
+					},
+					"speakers": {
+						"items": {
+							"$ref": "#/components/schemas/ISpeaker"
+						},
+						"type": "array"
+					},
+					"source": {
+						"$ref": "#/components/schemas/ISource"
+					},
+					"assetId": {
+						"type": "string"
+					},
+					"playback": {
+						"$ref": "#/components/schemas/IPlayback"
+					},
+					"videoUrl": {
+						"type": "string"
+					},
+					"playbackId": {
+						"type": "string"
+					},
+					"track": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"coverImage": {
+						"type": "string"
+					},
+					"eventSlug": {
+						"type": "string"
+					},
+					"videoTranscription": {
+						"type": "string"
+					},
+					"aiDescription": {
+						"type": "string"
+					},
+					"autoLabels": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"ipfsURI": {
+						"type": "string"
+					},
+					"mintable": {
+						"type": "boolean"
+					},
+					"published": {
+						"type": "boolean"
+					},
+					"type": {
+						"$ref": "#/components/schemas/SessionType"
+					},
+					"createdAt": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "string",
+								"format": "date-time"
+							}
+						]
+					},
+					"nftCollections": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"socials": {
+						"items": {
+							"properties": {
+								"date": {
+									"type": "number",
+									"format": "double"
+								},
+								"name": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"date",
+								"name"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"firebaseId": {
+						"type": "string"
+					},
+					"talkType": {
+						"type": "string"
+					},
+					"clippingStatus": {
+						"$ref": "#/components/schemas/ClippingStatus"
+					},
+					"autolabels": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"organizationId",
+					"name",
+					"description",
+					"start",
+					"end",
+					"type",
+					"speakers"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UpdateSessionDto": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"start": {
+						"type": "number",
+						"format": "double"
+					},
+					"end": {
+						"type": "number",
+						"format": "double"
+					},
+					"startClipTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"endClipTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"stageId": {
+						"type": "string"
+					},
+					"speakers": {
+						"items": {
+							"$ref": "#/components/schemas/Omit_ISpeaker.organizationId_"
+						},
+						"type": "array"
+					},
+					"source": {
+						"$ref": "#/components/schemas/ISource"
+					},
+					"playback": {
+						"$ref": "#/components/schemas/IPlayback"
+					},
+					"videoUrl": {
+						"type": "string"
+					},
+					"playbackId": {
+						"type": "string"
+					},
+					"eventId": {
+						"type": "string"
+					},
+					"organizationId": {
+						"type": "string"
+					},
+					"track": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"coverImage": {
+						"type": "string"
+					},
+					"eventSlug": {
+						"type": "string"
+					},
+					"videoTranscription": {
+						"type": "string"
+					},
+					"aiDescription": {
+						"type": "string"
+					},
+					"autolabels": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"assetId": {
+						"type": "string"
+					},
+					"ipfsURI": {
+						"type": "string"
+					},
+					"published": {
+						"type": "boolean"
+					},
+					"type": {
+						"$ref": "#/components/schemas/SessionType"
+					},
+					"nftURI": {
+						"type": "string"
+					},
+					"mintable": {
+						"type": "boolean"
+					},
+					"nftCollections": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"active": {
+						"type": "boolean"
+					},
+					"socials": {
+						"items": {
+							"properties": {
+								"date": {
+									"type": "number",
+									"format": "double"
+								},
+								"name": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"date",
+								"name"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"createdAt": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"start",
+					"end",
+					"speakers",
+					"organizationId",
+					"type"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_Array_ISession__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/ISession"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Pick_UploadSessionDto.organizationId-or-sessionId_": {
+				"properties": {
+					"organizationId": {
+						"type": "string"
+					},
+					"sessionId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"sessionId"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"UploadSessionDto": {
+				"properties": {
+					"socialId": {
+						"type": "string"
+					},
+					"organizationId": {
+						"type": "string"
+					},
+					"sessionId": {
+						"type": "string"
+					},
+					"token": {
+						"properties": {
+							"secret": {
+								"type": "string"
+							},
+							"key": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"secret"
+						],
+						"type": "object"
+					},
+					"type": {
+						"type": "string"
+					},
+					"text": {
+						"type": "string"
+					},
+					"refreshToken": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"sessionId",
+					"type"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse__sessions-Array_ISession_--totalDocuments-number--pageable_58__page-number--size-number___": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"properties": {
+							"pageable": {
+								"properties": {
+									"size": {
+										"type": "number",
+										"format": "double"
+									},
+									"page": {
+										"type": "number",
+										"format": "double"
+									}
+								},
+								"required": [
+									"size",
+									"page"
+								],
+								"type": "object"
+							},
+							"totalDocuments": {
+								"type": "number",
+								"format": "double"
+							},
+							"sessions": {
+								"items": {
+									"$ref": "#/components/schemas/ISession"
+								},
+								"type": "array"
+							}
+						},
+						"required": [
+							"pageable",
+							"totalDocuments",
+							"sessions"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ImportType": {
+				"enum": [
+					"gsheet",
+					"pretalx"
+				],
+				"type": "string"
+			},
+			"Pick_IScheduleImporterDto.url-or-type-or-organizationId_": {
+				"properties": {
+					"organizationId": {
+						"type": "string"
+					},
+					"type": {
+						"$ref": "#/components/schemas/ImportType"
+					},
+					"url": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"organizationId",
+					"type",
+					"url"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Pick_IScheduleImporterDto.url-or-type-or-organizationId-or-stageId_": {
+				"properties": {
+					"organizationId": {
+						"type": "string"
+					},
+					"stageId": {
+						"type": "string"
+					},
+					"type": {
+						"$ref": "#/components/schemas/ImportType"
+					},
+					"url": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"organizationId",
+					"stageId",
+					"type",
+					"url"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"IStandardResponse_IOrganization_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/IOrganization"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Pick_IOrganization.Exclude_keyofIOrganization._id__": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"bio": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"socials": {
+						"items": {
+							"$ref": "#/components/schemas/ISocials"
+						},
+						"type": "array"
+					},
+					"url": {
+						"type": "string"
+					},
+					"email": {
+						"type": "string"
+					},
+					"logo": {
+						"type": "string"
+					},
+					"location": {
+						"type": "string"
+					},
+					"accentColor": {
+						"type": "string"
+					},
+					"banner": {
+						"type": "string"
+					},
+					"walletAddress": {
+						"type": "string"
+					},
+					"address": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"email",
+					"logo"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"CreateOrganizationDto": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"bio": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"socials": {
+						"items": {
+							"$ref": "#/components/schemas/ISocials"
+						},
+						"type": "array"
+					},
+					"url": {
+						"type": "string"
+					},
+					"email": {
+						"type": "string"
+					},
+					"logo": {
+						"type": "string"
+					},
+					"location": {
+						"type": "string"
+					},
+					"accentColor": {
+						"type": "string"
+					},
+					"banner": {
+						"type": "string"
+					},
+					"walletAddress": {
+						"type": "string"
+					},
+					"address": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"email",
+					"logo",
+					"walletAddress"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UpdateOrganizationDto": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"logo": {
+						"type": "string"
+					},
+					"email": {
+						"type": "string"
+					},
+					"walletAddress": {
+						"type": "string"
+					},
+					"banner": {
+						"type": "string"
+					},
+					"organizationId": {
+						"type": "string"
+					},
+					"url": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"logo",
+					"email",
+					"walletAddress"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Pick_CreateOrganizationDto.address_": {
+				"properties": {
+					"address": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"IStandardResponse_Array_IOrganization__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/IOrganization"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_Array_IUser__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/IUser"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Pick_CreateOrganizationDto.walletAddress_": {
+				"properties": {
+					"walletAddress": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"walletAddress"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"NftCollectionType": {
+				"enum": [
+					"single",
+					"multiple"
+				],
+				"type": "string"
+			},
+			"INftCollection": {
+				"properties": {
+					"_id": {
+						"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+					},
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"thumbnail": {
+						"type": "string"
+					},
+					"type": {
+						"$ref": "#/components/schemas/NftCollectionType"
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"videos": {
+						"items": {
+							"properties": {
+								"ipfsURI": {
+									"type": "string"
+								},
+								"stageId": {
+									"type": "string"
+								},
+								"sessionId": {
+									"type": "string"
+								},
+								"type": {
+									"type": "string"
+								},
+								"index": {
+									"type": "number",
+									"format": "double"
+								}
+							},
+							"required": [
+								"type"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"contractAddress": {
+						"type": "string"
+					},
+					"ipfsPath": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_INftCollection_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/INftCollection"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateNftCollectionDto": {
+				"properties": {
+					"_id": {
+						"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+					},
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"thumbnail": {
+						"type": "string"
+					},
+					"type": {
+						"$ref": "#/components/schemas/NftCollectionType"
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"videos": {
+						"items": {
+							"properties": {
+								"ipfsURI": {
+									"type": "string"
+								},
+								"stageId": {
+									"type": "string"
+								},
+								"sessionId": {
+									"type": "string"
+								},
+								"type": {
+									"type": "string"
+								},
+								"index": {
+									"type": "number",
+									"format": "double"
+								}
+							},
+							"required": [
+								"ipfsURI",
+								"type",
+								"index"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"contractAddress": {
+						"type": "string"
+					},
+					"ipfsPath": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"thumbnail",
+					"type",
+					"organizationId",
+					"videos"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse__ipfsPath-string--videos-Array_any___": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"properties": {
+							"videos": {
+								"items": {},
+								"type": "array"
+							},
+							"ipfsPath": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"videos",
+							"ipfsPath"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UpdateNftCollectionDto": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"thumbnail": {
+						"type": "string"
+					},
+					"contractAddress": {
+						"type": "string"
+					},
+					"ipfsPath": {
+						"type": "string"
+					},
+					"type": {
+						"$ref": "#/components/schemas/NftCollectionType"
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							}
+						]
+					},
+					"videos": {
+						"items": {
+							"properties": {
+								"ipfsURI": {
+									"type": "string"
+								},
+								"stageId": {
+									"type": "string"
+								},
+								"sessionId": {
+									"type": "string"
+								},
+								"type": {
+									"type": "string"
+								},
+								"index": {
+									"type": "number",
+									"format": "double"
+								}
+							},
+							"required": [
+								"type"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_Array_INftCollection__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/INftCollection"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"GSheetConfig": {
+				"properties": {
+					"sheetId": {
+						"type": "string"
+					},
+					"apiKey": {
+						"type": "string"
+					},
+					"driveId": {
+						"type": "string"
+					},
+					"driveApiKey": {
+						"type": "string"
+					},
+					"url": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"PretalxConfig": {
+				"properties": {
+					"url": {
+						"type": "string"
+					},
+					"apiToken": {
+						"type": "string"
+					},
+					"sheetId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"apiToken"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IDataImporter": {
+				"anyOf": [
+					{
+						"properties": {
+							"config": {
+								"$ref": "#/components/schemas/GSheetConfig"
+							},
+							"type": {
+								"type": "string",
+								"enum": [
+									"gsheet"
+								],
+								"nullable": false
+							}
+						},
+						"required": [
+							"config",
+							"type"
+						],
+						"type": "object"
+					},
+					{
+						"properties": {
+							"config": {
+								"$ref": "#/components/schemas/PretalxConfig"
+							},
+							"type": {
+								"type": "string",
+								"enum": [
+									"pretalx"
+								],
+								"nullable": false
+							}
+						},
+						"required": [
+							"config",
+							"type"
+						],
+						"type": "object"
+					}
+				]
+			},
+			"IDataExporter": {
+				"properties": {
+					"config": {
+						"$ref": "#/components/schemas/GSheetConfig"
+					},
+					"type": {
+						"type": "string",
+						"enum": [
+							"gdrive"
+						],
+						"nullable": false
+					}
+				},
+				"required": [
+					"config",
+					"type"
+				],
+				"type": "object"
+			},
+			"IPlugins": {
+				"properties": {
+					"disableChat": {
+						"type": "boolean"
+					},
+					"hideSchedule": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"disableChat"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IEventNFT": {
+				"properties": {
+					"address": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"symbol": {
+						"type": "string"
+					},
+					"uri": {
+						"type": "string"
+					},
+					"maxSupply": {
+						"type": "string"
+					},
+					"mintFee": {
+						"type": "string"
+					},
+					"startTime": {
+						"type": "string"
+					},
+					"endTime": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IEvent": {
+				"properties": {
+					"_id": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"start": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"end": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"location": {
+						"type": "string"
+					},
+					"logo": {
+						"type": "string"
+					},
+					"banner": {
+						"type": "string"
+					},
+					"startTime": {
+						"type": "string"
+					},
+					"endTime": {
+						"type": "string"
+					},
+					"organizationId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"dataImporter": {
+						"items": {
+							"$ref": "#/components/schemas/IDataImporter"
+						},
+						"type": "array"
+					},
+					"eventCover": {
+						"type": "string"
+					},
+					"archiveMode": {
+						"type": "boolean"
+					},
+					"website": {
+						"type": "string"
+					},
+					"timezone": {
+						"type": "string"
+					},
+					"accentColor": {
+						"type": "string"
+					},
+					"unlisted": {
+						"type": "boolean"
+					},
+					"dataExporter": {
+						"items": {
+							"$ref": "#/components/schemas/IDataExporter"
+						},
+						"type": "array"
+					},
+					"enableVideoDownloader": {
+						"type": "boolean"
+					},
+					"plugins": {
+						"$ref": "#/components/schemas/IPlugins"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"eventNFT": {
+						"$ref": "#/components/schemas/IEventNFT"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"start",
+					"end",
+					"location",
+					"organizationId",
+					"timezone"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_IEvent_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/IEvent"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateEventDto": {
+				"properties": {
+					"_id": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"start": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"end": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"location": {
+						"type": "string"
+					},
+					"logo": {
+						"type": "string"
+					},
+					"banner": {
+						"type": "string"
+					},
+					"startTime": {
+						"type": "string"
+					},
+					"endTime": {
+						"type": "string"
+					},
+					"organizationId": {
+						"type": "string"
+					},
+					"dataImporter": {
+						"items": {
+							"$ref": "#/components/schemas/IDataImporter"
+						},
+						"type": "array"
+					},
+					"eventCover": {
+						"type": "string"
+					},
+					"archiveMode": {
+						"type": "boolean"
+					},
+					"website": {
+						"type": "string"
+					},
+					"timezone": {
+						"type": "string"
+					},
+					"accentColor": {
+						"type": "string"
+					},
+					"unlisted": {
+						"type": "boolean"
+					},
+					"dataExporter": {
+						"items": {
+							"$ref": "#/components/schemas/IDataExporter"
+						},
+						"type": "array"
+					},
+					"enableVideoDownloader": {
+						"type": "boolean"
+					},
+					"plugins": {
+						"$ref": "#/components/schemas/IPlugins"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"eventNFT": {
+						"$ref": "#/components/schemas/IEventNFT"
+					},
+					"nftAddress": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"start",
+					"end",
+					"location",
+					"organizationId",
+					"timezone",
+					"logo",
+					"banner"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UpdateEventDto": {
+				"properties": {
+					"_id": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"start": {
+						"type": "string"
+					},
+					"end": {
+						"type": "string"
+					},
+					"location": {
+						"type": "string"
+					},
+					"logo": {
+						"type": "string"
+					},
+					"banner": {
+						"type": "string"
+					},
+					"startTime": {
+						"type": "string"
+					},
+					"endTime": {
+						"type": "string"
+					},
+					"organizationId": {
+						"type": "string"
+					},
+					"dataImporter": {
+						"items": {
+							"$ref": "#/components/schemas/IDataImporter"
+						},
+						"type": "array"
+					},
+					"eventCover": {
+						"type": "string"
+					},
+					"archiveMode": {
+						"type": "boolean"
+					},
+					"website": {
+						"type": "string"
+					},
+					"timezone": {
+						"type": "string"
+					},
+					"accentColor": {
+						"type": "string"
+					},
+					"unlisted": {
+						"type": "boolean"
+					},
+					"dataExporter": {
+						"items": {
+							"$ref": "#/components/schemas/IDataExporter"
+						},
+						"type": "array"
+					},
+					"enableVideoDownloader": {
+						"type": "boolean"
+					},
+					"plugins": {
+						"$ref": "#/components/schemas/IPlugins"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"eventNFT": {
+						"$ref": "#/components/schemas/IEventNFT"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"start",
+					"end",
+					"location",
+					"organizationId",
+					"timezone",
+					"logo",
+					"banner"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_Array_IEvent__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/IEvent"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IFrom": {
+				"properties": {
+					"identity": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"identity"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IChat": {
+				"properties": {
+					"stageId": {
+						"anyOf": [
+							{
+								"$ref": "#/components/schemas/mongoose.Types.ObjectId"
+							},
+							{
+								"type": "string"
+							}
+						]
+					},
+					"message": {
+						"type": "string"
+					},
+					"from": {
+						"$ref": "#/components/schemas/IFrom"
+					},
+					"timestamp": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"stageId",
+					"message",
+					"from",
+					"timestamp"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_IChat_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"$ref": "#/components/schemas/IChat"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateChatDto": {
+				"properties": {
+					"stageId": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"from": {
+						"$ref": "#/components/schemas/IFrom"
+					},
+					"timestamp": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"stageId",
+					"message",
+					"from",
+					"timestamp"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_IChat-Array_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/IChat"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse__user-IUser--token-string__": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"properties": {
+							"token": {
+								"type": "string"
+							},
+							"user": {
+								"$ref": "#/components/schemas/IUser"
+							}
+						},
+						"required": [
+							"token",
+							"user"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UserDto": {
+				"properties": {
+					"token": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"token"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"IStandardResponse_boolean_": {
+				"properties": {
+					"status": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"status",
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			}
+		},
+		"securitySchemes": {
+			"jwt": {
+				"name": "Authorization",
+				"type": "http",
+				"scheme": "bearer",
+				"bearerFormat": "JWT",
+				"in": "header"
+			}
+		}
+	},
+	"info": {
+		"title": "streameth-api",
+		"version": "3.0.0",
+		"contact": {}
+	},
+	"paths": {
+		"/users/{walletAddress}": {
+			"get": {
+				"operationId": "GetUserById",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IUser_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"User"
+				],
+				"security": [
+					{
+						"jwt": []
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "walletAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/Tickets": {
+			"post": {
+				"operationId": "CreateTicket",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_ISupport_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Creates support ticket",
+				"tags": [
+					"Support"
+				],
+				"security": [
+					{
+						"jwt": []
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateSupportTicketDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetAllTickets",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_ISupport-Array_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get all support tickets",
+				"tags": [
+					"Support"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/streams/multistream": {
+			"post": {
+				"operationId": "CreateMultiStream",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_any_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Create Multistream",
+				"tags": [
+					"Stream"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateMultiStreamDto"
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "DeleteMultiStream",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Delete Multistream",
+				"tags": [
+					"Stream"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/DeleteMultiStreamDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/streams/asset": {
+			"post": {
+				"operationId": "CreateAsset",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse__url-string--assetId-string__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Create stream asset",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {}
+						}
+					}
+				}
+			}
+		},
+		"/streams/{streamId}": {
+			"get": {
+				"operationId": "GetStream",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_any_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get Stream",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "streamId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/streams/asset/{assetId}": {
+			"get": {
+				"operationId": "GetAsset",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_any_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get Asset",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "assetId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/streams/asset/url/{assetId}": {
+			"get": {
+				"operationId": "GetVideoUrl",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_string_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get Video url",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "assetId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/streams/asset/phase-action/{assetId}": {
+			"get": {
+				"operationId": "GetPhaseAction",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse__playbackUrl-string--phaseStatus-string__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get Video Phase Action",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "assetId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/streams/metric/{playbackId}": {
+			"get": {
+				"operationId": "GetSessionMetrics",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse__viewCount-number--playTimeMins-number__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get stream metrics",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "playbackId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/streams/recording/{streamId}": {
+			"get": {
+				"operationId": "GetStreamRecordings",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_any_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get stream recordings",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "streamId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/streams/upload/{assetId}": {
+			"get": {
+				"operationId": "UploadToIpfs",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_string_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Upload",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "assetId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/streams/clip": {
+			"post": {
+				"operationId": "CreateClip",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_any_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Create clip",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateClipDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/streams/thumbnail/generate": {
+			"post": {
+				"operationId": "GenerateThumbnail",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_any_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Generate thumbnail",
+				"tags": [
+					"Stream"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {}
+						}
+					}
+				}
+			}
+		},
+		"/states": {
+			"post": {
+				"operationId": "CreateState",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IState_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"State"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateStateDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetAllStates",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_IState__"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"State"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "eventId",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sessionId",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "eventSlug",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "type",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/states/{stateId}": {
+			"put": {
+				"operationId": "UpdateState",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IState_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"State"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "stateId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateStateDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/stages": {
+			"post": {
+				"operationId": "CreateStage",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IStage_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Create Session",
+				"tags": [
+					"Stage"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateStageDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetAllStages",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_IStage__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get All Stage",
+				"tags": [
+					"Stage"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "published",
+						"required": false,
+						"schema": {
+							"type": "boolean"
+						}
+					}
+				]
+			}
+		},
+		"/stages/{stageId}": {
+			"put": {
+				"operationId": "EditStage",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IStage_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Update Stage",
+				"tags": [
+					"Stage"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "stageId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateStageDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetStageById",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IStage_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get Stage by id",
+				"tags": [
+					"Stage"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "stageId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "DeleteStage",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Delete Stage",
+				"tags": [
+					"Stage"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "stageId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/OrgIdDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/stages/event/{eventId}": {
+			"get": {
+				"operationId": "GetAllStagesForEvent",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_IStage__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get All Stage for Event",
+				"tags": [
+					"Stage"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "eventId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/stages/organization/{organizationId}": {
+			"get": {
+				"operationId": "GetAllStagesForOrganization",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_IStage__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get All Stage for Organization",
+				"tags": [
+					"Stage"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/stages/livestream": {
+			"post": {
+				"operationId": "YoutubeStage",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse__streamKey-string--ingestUrl-string__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Create Livestream on youtube & twitter",
+				"tags": [
+					"Stage"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateLiveStreamDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/speakers": {
+			"post": {
+				"operationId": "CreateSpeaker",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_ISpeaker_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Speaker"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateSpeakerDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/speakers/{speakerId}": {
+			"get": {
+				"operationId": "GetSpeaker",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_ISpeaker_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Speaker"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "speakerId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/speakers/event/{eventId}": {
+			"get": {
+				"operationId": "GetAllSpeakersForEvent",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_ISpeaker__"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Speaker"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "eventId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/sessions": {
+			"post": {
+				"operationId": "CreateSession",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_ISession_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Create Session",
+				"tags": [
+					"Session"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateSessionDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetAllSessions",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse__sessions-Array_ISession_--totalDocuments-number--pageable_58__page-number--size-number___"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get All Session",
+				"tags": [
+					"Session"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "event",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "organization",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "speaker",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "stageId",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "onlyVideos",
+						"required": false,
+						"schema": {
+							"type": "boolean"
+						}
+					},
+					{
+						"in": "query",
+						"name": "page",
+						"required": false,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "size",
+						"required": false,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "timestamp",
+						"required": false,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "assetId",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "published",
+						"required": false,
+						"schema": {
+							"type": "boolean"
+						}
+					},
+					{
+						"in": "query",
+						"name": "type",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/sessions/{sessionId}": {
+			"put": {
+				"operationId": "EditSession",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_ISession_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Update Session",
+				"tags": [
+					"Session"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "sessionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateSessionDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetSessionById",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_ISession_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Fetch session by id",
+				"tags": [
+					"Session"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "sessionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "DeleteSession",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Delete Session",
+				"tags": [
+					"Session"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "sessionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/OrgIdDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/sessions/organization/{organizationId}": {
+			"get": {
+				"operationId": "GetOrgEventSessions",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_ISession__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get all event sessions",
+				"tags": [
+					"Session"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/sessions/search": {
+			"get": {
+				"operationId": "FilterSession",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_ISession__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Search sessions",
+				"tags": [
+					"Session"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "search",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/sessions/{organizationSlug}/search": {
+			"get": {
+				"operationId": "FilterSessionByOrganisation",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_ISession__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Search sessions per organisation",
+				"tags": [
+					"Session"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationSlug",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/sessions/transcriptions": {
+			"post": {
+				"operationId": "SessionTranscriptions",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Transcribe session",
+				"tags": [
+					"Session"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pick_UploadSessionDto.organizationId-or-sessionId_"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/sessions/upload": {
+			"post": {
+				"operationId": "UploadSessionToSocials",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Publish session to socials",
+				"tags": [
+					"Session"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UploadSessionDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/schedule/import": {
+			"post": {
+				"operationId": "ImportSchdeule",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Schedule"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pick_IScheduleImporterDto.url-or-type-or-organizationId_"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/schedule/import/stage": {
+			"post": {
+				"operationId": "ImportSchdeuleByStage",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Schedule"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pick_IScheduleImporterDto.url-or-type-or-organizationId-or-stageId_"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/schedule/import/save": {
+			"post": {
+				"operationId": "Save",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Schedule"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"scheduleId": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"scheduleId"
+								],
+								"type": "object"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/organizations": {
+			"post": {
+				"operationId": "CreateOrganization",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IOrganization_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Create organization",
+				"tags": [
+					"Organization"
+				],
+				"security": [
+					{
+						"jwt": []
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateOrganizationDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetAllOrganizations",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_IOrganization__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get all organizations",
+				"tags": [
+					"Organization"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/organizations/{organizationId}": {
+			"put": {
+				"operationId": "EditOrganization",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IOrganization_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Update organization",
+				"tags": [
+					"Organization"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateOrganizationDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetOrganizationById",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IOrganization_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get organization by",
+				"tags": [
+					"Organization"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "DeleteOrganization",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Delete organization",
+				"tags": [
+					"Organization"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/organizations/member/{organizationId}": {
+			"put": {
+				"operationId": "UpdateOrgMembers",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Add member to organization",
+				"tags": [
+					"Organization"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pick_CreateOrganizationDto.address_"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetAllOrgMembers",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_IUser__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get all organization members",
+				"tags": [
+					"Organization"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"delete": {
+				"operationId": "DeleteOrgMember",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Delete organization member",
+				"tags": [
+					"Organization"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pick_CreateOrganizationDto.walletAddress_"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/organizations/socials/{organizationId}": {
+			"put": {
+				"operationId": "UpdateOrgSocials",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Add socials to organization",
+				"tags": [
+					"Organization"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/ISocials"
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "DeleteOrgSocial",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Delete organization social",
+				"tags": [
+					"Organization"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"destinationId": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"destinationId"
+								],
+								"type": "object"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/collections": {
+			"post": {
+				"operationId": "CreateNftCollection",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_INftCollection_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Create nft collection",
+				"tags": [
+					"Collections"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateNftCollectionDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetAllCollections",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_INftCollection__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get all nft collections",
+				"tags": [
+					"Collections"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/collections/metadata/generate": {
+			"post": {
+				"operationId": "GenerateNftMetadata",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse__ipfsPath-string--videos-Array_any___"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Generate nft metadata",
+				"tags": [
+					"Collections"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateNftCollectionDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/collections/{collectionId}": {
+			"put": {
+				"operationId": "UpdateNftCollection",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_INftCollection_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Update nft collection",
+				"tags": [
+					"Collections"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "collectionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateNftCollectionDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetNftCollectionById",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_INftCollection_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get Nft collection by id",
+				"tags": [
+					"Collections"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "collectionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/collections/organization/{organizationId}": {
+			"get": {
+				"operationId": "GetAllOrganizationNft",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_INftCollection__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get Nft collections by organization",
+				"tags": [
+					"Collections"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "organizationId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/": {
+			"get": {
+				"operationId": "Index",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Index"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/upload": {
+			"post": {
+				"operationId": "UploadImges",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Index"
+				],
+				"security": [
+					{
+						"jwt": []
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"multipart/form-data": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"file": {
+										"type": "string",
+										"format": "binary"
+									},
+									"directory": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"file",
+									"directory"
+								]
+							}
+						}
+					}
+				}
+			}
+		},
+		"/webhook": {
+			"post": {
+				"operationId": "Webhook",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Index"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "header",
+						"name": "livepeer-signature",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {}
+						}
+					}
+				}
+			}
+		},
+		"/events": {
+			"post": {
+				"operationId": "CreateEvent",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IEvent_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Creates Event",
+				"tags": [
+					"Event"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateEventDto"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetAllEvents",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_Array_IEvent__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get All Event",
+				"tags": [
+					"Event"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "organizationId",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "unlisted",
+						"required": false,
+						"schema": {
+							"type": "boolean"
+						}
+					}
+				]
+			}
+		},
+		"/events/{eventId}": {
+			"get": {
+				"operationId": "GetEventById",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IEvent_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get Event",
+				"tags": [
+					"Event"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "eventId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"put": {
+				"operationId": "EditEvent",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IEvent_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Update Event",
+				"tags": [
+					"Event"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "eventId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateEventDto"
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "DeleteEvent",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Delete Event",
+				"tags": [
+					"Event"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "eventId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/OrgIdDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/events/import/{eventId}": {
+			"put": {
+				"operationId": "EvenImporter",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_void_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Event importer",
+				"tags": [
+					"Event"
+				],
+				"security": [
+					{
+						"jwt": [
+							"org"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "eventId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/OrgIdDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/chats": {
+			"post": {
+				"operationId": "CreateCHar",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IChat_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Creates Chat",
+				"tags": [
+					"Chat"
+				],
+				"security": [
+					{
+						"jwt": []
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateChatDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/chats/{stageId}": {
+			"get": {
+				"operationId": "GetChatStageById",
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_IChat-Array_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Get all chats by stage",
+				"tags": [
+					"Chat"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "stageId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/auth/login": {
+			"post": {
+				"operationId": "Login",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse__user-IUser--token-string__"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Login",
+				"tags": [
+					"Auth"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UserDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/auth/verify-token": {
+			"post": {
+				"operationId": "VerifyToken",
+				"responses": {
+					"201": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/IStandardResponse_boolean_"
+								}
+							}
+						}
+					}
+				},
+				"summary": "Verify auth token",
+				"tags": [
+					"Auth"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UserDto"
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"servers": [
+		{
+			"url": "/streameth-platform-packages-new2"
+		}
+	]
 }

--- a/packages/server/src/utils/pulse.cron.ts
+++ b/packages/server/src/utils/pulse.cron.ts
@@ -1,0 +1,32 @@
+import { config } from '@config';
+import Pulse from '@pulsecron/pulse';
+import { refetchAssets } from './livepeer';
+import { logger } from './logger';
+
+const pulse = new Pulse({
+  db: { address: config.db.host, collection: 'agendajobs' },
+  defaultConcurrency: 4,
+  maxConcurrency: 4,
+  processEvery: '10 seconds',
+  resumeOnRestart: true,
+});
+
+pulse.define('refetch assets', async (job) => {
+  try {
+    await refetchAssets();
+    logger.info('Refetching assets completed');
+  } catch (error) {
+    logger.error('Error in refetch assets job:', error);
+  }
+});
+
+export async function jobs() {
+  try {
+    await pulse.start();
+    //At 12:00 AM, on day 1 of the month
+    await pulse.every('0 0 1 * *', 'refetch assets');
+    logger.info('Refetch assets job scheduled');
+  } catch (error) {
+    logger.error('Error in JobWorker:', error);
+  }
+}

--- a/packages/video-uploader/src/audio-queue.ts
+++ b/packages/video-uploader/src/audio-queue.ts
@@ -1,46 +1,47 @@
-import { config } from "dotenv";
-import FormData from "form-data";
-import fs from "fs";
-import { MongoClient, ObjectId } from "mongodb";
-import fetch from "node-fetch";
-import { downloadM3U8ToMP3 } from "./utils/ffmpeg";
-import { jsonToVtt, uploadFile } from "./utils/helper";
-import { logger } from "./utils/logger";
-import connection from "./utils/mq";
+import { config } from 'dotenv';
+import FormData from 'form-data';
+import fs from 'fs';
+import { MongoClient, ObjectId } from 'mongodb';
+import fetch from 'node-fetch';
+import { downloadM3U8ToMP3 } from './utils/ffmpeg';
+import { jsonToVtt, uploadFile } from './utils/helper';
+import { logger } from './utils/logger';
+import connection from './utils/mq';
 config();
 
 const client = new MongoClient(process.env.DB_HOST);
 const db = client.db(process.env.DB_NAME);
-const sessions = db.collection("sessions");
+const sessions = db.collection('sessions');
 
 const convertAudioToText = async (
   sessionId: string,
-  filepath: string,
-): Promise<{ url: string; text: string }> => {
+  filepath: string
+): Promise<{ url: string; text: string; chunks: string[] }> => {
   try {
     const form = new FormData();
-    form.append("audio", fs.createReadStream(filepath));
-    form.append("model_id", "openai/whisper-large-v3");
+    form.append('audio', fs.createReadStream(filepath));
+    form.append('model_id', 'openai/whisper-large-v3');
     const response = await fetch(
       `${process.env.LIVEPEER_GATEWAY_URL}/audio-to-text`,
       {
-        method: "POST",
+        method: 'POST',
         headers: {
           Authorization: `Bearer ${process.env.LIVEPEER_GATEWAY_KEY}`,
           ...form.getHeaders(),
         },
         body: form,
-      },
+      }
     );
     const data = await response.json();
     const transcriptions = jsonToVtt(data);
     const url = await uploadFile(
       `transcriptions/${sessionId}.vtt`,
-      transcriptions,
+      transcriptions
     );
     return {
       url: url,
       text: data.text,
+      chunks: data.chunks,
     };
   } catch (e) {
     logger.error(e);
@@ -49,7 +50,7 @@ const convertAudioToText = async (
 
 async function audioConverter() {
   try {
-    const queue = "audio";
+    const queue = 'audio';
     const channel = await (await connection).createChannel();
     channel.assertQueue(queue, {
       durable: true,
@@ -63,32 +64,35 @@ async function audioConverter() {
           await downloadM3U8ToMP3(
             data.session.videoUrl,
             data.session.slug,
-            "./tmp",
+            './tmp'
           );
           const transcript = await convertAudioToText(
             data.sessionId,
-            `./tmp/${data.session.slug}.mp3`,
+            `./tmp/${data.session.slug}.mp3`
           );
           await sessions.findOneAndUpdate(
             { _id: ObjectId.createFromHexString(data.sessionId) },
             {
               $set: {
-                videoTranscription: transcript.url,
-                aiDescription: transcript.text,
+                transcripts: {
+                  subtitleUrl: transcript.url,
+                  chunks: transcript.chunks,
+                  text: transcript.text,
+                },
               },
-            },
+            }
           );
           fs.unlinkSync(`./tmp/${data.session.slug}.mp3`);
         } catch (e) {
-          logger.error("error", e);
+          logger.error('error', e);
         }
       },
       {
         noAck: true,
-      },
+      }
     );
   } catch (e) {
-    logger.error("error", e);
+    logger.error('error', e);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3776,6 +3776,18 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@pulsecron/pulse@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@pulsecron/pulse/-/pulse-1.6.3.tgz#dd8e708b169b888832e28ea5dd7dcc8db1ae35eb"
+  integrity sha512-ND7mazvEuovULoPsadK29S0lf6jn8oB0PKz9jZgI9KAARTqxtd8gTBzwWzUlkTqlgUvebDz2GVYPORdgwVOj7Q==
+  dependencies:
+    cron-parser "^4.9.0"
+    date.js "~0.3.3"
+    debug "~4.3.4"
+    human-interval "~2.0.1"
+    moment-timezone "^0.5.45"
+    mongodb "^6.5.0"
+
 "@radix-ui/number@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-1.1.0.tgz#1e95610461a09cdf8bb05c152e76ca1278d5da46"
@@ -8941,7 +8953,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cron-parser@^4.2.1:
+cron-parser@^4.2.1, cron-parser@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-4.9.0.tgz#0340694af3e46a0894978c6f52a6dbb5c0f11ad5"
   integrity sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==
@@ -9125,6 +9137,13 @@ date-fns@^3.2.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
   integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
 
+date.js@~0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/date.js/-/date.js-0.3.3.tgz#ef1e92332f507a638795dbb985e951882e50bbda"
+  integrity sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==
+  dependencies:
+    debug "~3.1.0"
+
 dateformat@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
@@ -9184,6 +9203,13 @@ debug@^3.2.6, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -12229,6 +12255,13 @@ https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.2, https-proxy-agent@^7.0.5:
     agent-base "^7.0.2"
     debug "4"
 
+human-interval@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/human-interval/-/human-interval-2.0.1.tgz#655baf606c7067bb26042dcae14ec777b099af15"
+  integrity sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==
+  dependencies:
+    numbered "^1.1.0"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -15051,7 +15084,7 @@ mongodb@6.7.0:
     bson "^6.7.0"
     mongodb-connection-string-url "^3.0.0"
 
-mongodb@^6.7.0:
+mongodb@^6.5.0, mongodb@^6.7.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-6.8.0.tgz#680450f113cdea6d2d9f7121fe57cd29111fd2ce"
   integrity sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==
@@ -15582,6 +15615,11 @@ number-to-bn@1.7.0:
   dependencies:
     bn.js "4.11.6"
     strip-hex-prefix "1.0.0"
+
+numbered@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/numbered/-/numbered-1.1.0.tgz#9fcd79564c73a84b9574e8370c3d8e58fe3c133c"
+  integrity sha512-pv/ue2Odr7IfYOO0byC1KgBI10wo5YDauLhxY6/saNzAdAs0r1SotGCPzzCLNPL0xtrAwWRialLu23AAu9xO1g==
 
 oauth-1.0a@^2.2.6:
   version "2.2.6"
@@ -18270,16 +18308,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18403,7 +18432,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18416,13 +18445,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -20255,7 +20277,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20268,15 +20290,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Pull Request Info

## Description
Implement monthly cron job to update sessions without playbackId

This PR:
-  Schedules the job to run at 00:00 on the first day of every month with pulse cron job.
- Fetch sessions lacking playbackId
- Refetches these sessions from Livepeer API to obtain latest data

The cron job ensures that our sessions stays up-to-date with the most recent information from Livepeer, particularly for sessions that were initially created without a playbackId.

Fixes (#856, #867)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published