### PR TITLE
💄 If only 1 org, instantly redirect there

### DIFF
--- a/packages/app/app/studio/(home)/page.tsx
+++ b/packages/app/app/studio/(home)/page.tsx
@@ -11,9 +11,14 @@ import Image from 'next/image';
 import { fetchUserAction } from '@/lib/actions/users';
 import { IExtendedUser } from '@/lib/types';
 import { Button } from '@/components/ui/button';
+import { redirect } from 'next/navigation';
 
 const Studio = async () => {
   const userData: IExtendedUser = await fetchUserAction({});
+
+  if (userData?.organizations?.length === 1) {
+    redirect(`/studio/${userData.organizations[0].slug}`);
+  }
 
   return (
     <div className="flex h-full flex-col">

--- a/packages/app/components/Layout/HomePageNavbar.tsx
+++ b/packages/app/components/Layout/HomePageNavbar.tsx
@@ -265,6 +265,13 @@ const PCNavBar = ({
           />
         )}
         <Navbar organization={currentOrganization} pages={pages} />
+        {organizations && organizations.length === 1 && (
+          <Link href="/studio/create">
+            <Button className="mr-2" variant="outlinePrimary">
+              Create Organization
+            </Button>
+          </Link>
+        )}
         {isStudio && <SignInUserButton />}
       </div>
     </NavigationMenu>


### PR DESCRIPTION
# Pull Request Template

## Type of Change

- [x] UI/UX improvement 💄

## Description
If the user only has 1 org, directly redirecting there improves UX quite a lot 

## Testing
Still didn't test this, can't seem to create a new user even though I did directly add it to Privy console... I'm missing something here.

## Impact
Quicker user redirects to the actual product.

## Additional Information
We need to include a `Create Organization` button somewhere else in the UI for users only with one Org, as there no other way of creating a new Org. Once the user creates a new org, we can make that button not visible to the user so we do not add too much clutter.

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings 
