### PR TITLE
🐛 Fix: share-dialog-in-stream-page-not-showing-proper-url

### DIFF
--- a/packages/app/app/studio/[organization]/livestreams/[streamId]/components/ShareAndEmbed.tsx
+++ b/packages/app/app/studio/[organization]/livestreams/[streamId]/components/ShareAndEmbed.tsx
@@ -26,22 +26,25 @@ import { copyToClipboard, generateEmbedCode } from '@/lib/utils/utils';
 import { Input } from '@/components/ui/input';
 
 interface ShareAndEmbedProps {
-  url: string;
+  url?: string;
+  organizationSlug: string;
   streamId: string;
   playerName: string;
 }
 
 const ShareAndEmbed: React.FC<ShareAndEmbedProps> = ({
-  url,
+  organizationSlug,
   streamId,
   playerName,
 }) => {
   const [open, setOpen] = useState(false);
-  const [currentUrl, setCurrentUrl] = useState(url);
+  const [currentUrl, setCurrentUrl] = useState('');
   const [embedCode, setEmbedCode] = useState('');
 
   useEffect(() => {
-    setCurrentUrl(url);
+    setCurrentUrl(
+      `${window.location.origin}/${organizationSlug}/livestream?stage=${streamId}`
+    );
     setEmbedCode(
       generateEmbedCode({
         url: typeof window !== 'undefined' ? window.location.origin : '',
@@ -49,7 +52,7 @@ const ShareAndEmbed: React.FC<ShareAndEmbedProps> = ({
         playerName: playerName,
       })
     );
-  }, [url, streamId, playerName]);
+  }, [streamId, playerName, organizationSlug]);
 
   const shareText = `Check out this livestream on @streameth!`;
 

--- a/packages/app/app/studio/[organization]/livestreams/[streamId]/page.tsx
+++ b/packages/app/app/studio/[organization]/livestreams/[streamId]/page.tsx
@@ -15,7 +15,6 @@ import { fetchAllSessions } from '@/lib/services/sessionService';
 import Sidebar from './components/Sidebar';
 import EditLivestream from '../components/EditLivestream';
 import ShareAndEmbed from './components/ShareAndEmbed';
-import { Session } from 'inspector';
 import { SessionType } from 'streameth-new-server/src/interfaces/session.interface';
 
 const Livestream = async ({ params, searchParams }: LivestreamPageParams) => {
@@ -37,8 +36,6 @@ const Livestream = async ({ params, searchParams }: LivestreamPageParams) => {
       onlyVideos: true,
     })
   ).sessions;
-
-  const shareUrl = `${process.env.NEXT_PUBLIC_APP_URL}/${params.organization}/livestream?stage=${stream._id}`;
 
   return (
     <div className="flex flex-col p-4 w-full h-full max-w-screen-3xl max-h-screen">
@@ -73,7 +70,7 @@ const Livestream = async ({ params, searchParams }: LivestreamPageParams) => {
 
             <div className="flex flex-row gap-2 ml-auto">
               <ShareAndEmbed
-                url={shareUrl}
+                organizationSlug={params.organization}
                 streamId={stream._id as string}
                 playerName={stream?.name}
               />


### PR DESCRIPTION
# Pull Request Template

## Title
Fixes share-dialog-in-stream-page-not-showing-proper-url

## Type of Change
- [ ] New feature ✨
- [ ] Bug fix 🐛
- [ ] Documentation update 📝
- [ ] Refactoring ♻️
- [ ] Hotfix 🚑️
- [ ] UI/UX improvement 💄

## Description
The error occurred because an environment variable was passed that was never updated in Vercel. I opted to use `window.location.origin` instead of relying on the environment variable.

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings 

closes #988