### PR TITLE
🐛 FIx Broken Social Share Thumbnails for sessions

### DIFF
--- a/packages/app/app/(vod)/watch/page.tsx
+++ b/packages/app/app/(vod)/watch/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata({
   if (!searchParams.session) return generalMetadata;
 
   if (!video) return generalMetadata;
-  const thumbnail = video.coverImage ?? (await generateThumbnailAction(video));
+  const thumbnail = video.coverImage || (await generateThumbnailAction(video));
 
   return watchMetadata({ session: video, thumbnail });
 }

--- a/packages/app/app/[organization]/watch/page.tsx
+++ b/packages/app/app/[organization]/watch/page.tsx
@@ -122,6 +122,6 @@ export async function generateMetadata({
 
   const thumbnail =
     session.coverImage || (await generateThumbnailAction(session));
-  console.log('thumbnail', thumbnail);
+
   return watchMetadata({ organization, session: session, thumbnail });
 }

--- a/packages/app/app/[organization]/watch/page.tsx
+++ b/packages/app/app/[organization]/watch/page.tsx
@@ -121,7 +121,7 @@ export async function generateMetadata({
   if (!session || !organization) return generalMetadata;
 
   const thumbnail =
-    session.coverImage ?? (await generateThumbnailAction(session));
-
+    session.coverImage || (await generateThumbnailAction(session));
+  console.log('thumbnail', thumbnail);
   return watchMetadata({ organization, session: session, thumbnail });
 }

--- a/packages/app/app/speaker/[session]/page.tsx
+++ b/packages/app/app/speaker/[session]/page.tsx
@@ -131,7 +131,7 @@ export async function generateMetadata({
   if (!session || !organization) return generalMetadata;
 
   const thumbnail =
-    session.coverImage ?? (await generateThumbnailAction(session));
+    session.coverImage || (await generateThumbnailAction(session));
 
   return watchMetadata({ organization, session, thumbnail });
 }


### PR DESCRIPTION
# Pull Request Template

## Title
🐛 Fix Broken Social Share Thumbnails for sessions

## Type of Change
- [ ] New feature ✨
- [x] Bug fix 🐛
- [ ] Documentation update 📝
- [ ] Refactoring ♻️
- [ ] Hotfix 🚑️
- [ ] UI/UX improvement 💄

## Description
The bug was caused by using Nullish Coalescing (??) operator which only considers null and undefined as `nullish` values. It will return the right-hand side only if the left-hand side is null or undefined.  

## Fix
```  const thumbnail = video.coverImage || (await generateThumbnailAction(video)); ```
Replace the operator with Logical OR (||) operator which returns the first truthy value. Since `coverImages` in our sessions are set to empty string by default, the Logical OR (||) will evaluate the right-hand side instead (generateThumbnailAction)


## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings 

closes #1038 
