### PR TITLE
💄Playhead dragging improved and preview

### DIFF
--- a/packages/app/app/studio/[organization]/clips/[stageId]/ClipContext.tsx
+++ b/packages/app/app/studio/[organization]/clips/[stageId]/ClipContext.tsx
@@ -240,9 +240,9 @@ export const ClipProvider = ({
     setHasMouseMoved(false);
 
     // Capture the current playhead position
-    if (videoRef.current) {
-      setPlayheadPosition(videoRef.current.currentTime);
-    }
+    // if (videoRef.current) {
+    //   setPlayheadPosition(videoRef.current.currentTime);
+    // }
     // Calculate the initial position based on the marker type
     if (marker === 'overlay') {
       const timelineRect = event.currentTarget.getBoundingClientRect();
@@ -304,7 +304,7 @@ export const ClipProvider = ({
           });
         }
         // Update currentTime state without changing video's currentTime
-        setCurrentTime(newTime);
+        // setCurrentTime(newTime);
       }
     },
     [

--- a/packages/app/app/studio/[organization]/clips/[stageId]/Timeline/PlayHead.tsx
+++ b/packages/app/app/studio/[organization]/clips/[stageId]/Timeline/PlayHead.tsx
@@ -64,7 +64,7 @@ const Playhead: React.FC<TimelinePlayheadProps> = ({
 
   return (
     <div
-      className="absolute top-0 bottom-0 w-1 bg-black border-white cursor-ew-resize z-10"
+      className="absolute top-0 bottom-0 w-1 bg-black border-white cursor-ew-resize z-[22]"
       style={{ left: `${getMarkerPosition(currentTime)}px` }}
       onMouseDown={handlePlayheadMouseDown}
     >

--- a/packages/app/app/studio/[organization]/clips/[stageId]/Timeline/TrimmControls.tsx
+++ b/packages/app/app/studio/[organization]/clips/[stageId]/Timeline/TrimmControls.tsx
@@ -64,33 +64,33 @@ const TrimmControls = ({
   //   ]
   // );
 
-  useEffect(() => {
-    const preventDefault = (e: Event) => e.preventDefault();
+  // useEffect(() => {
+  //   const preventDefault = (e: Event) => e.preventDefault();
 
-    window.addEventListener('keydown', (e) => {
-      if (selectedTooltip) {
-        // if (e.key === 'ArrowRight') {
-        //   handle1SecondIncrementDecrement(true, selectedTooltip);
-        // } else if (e.key === 'ArrowLeft') {
-        //   handle1SecondIncrementDecrement(false, selectedTooltip);
-        // }
-      }
+  //   window.addEventListener('keydown', (e) => {
+  //     if (selectedTooltip) {
+  //       // if (e.key === 'ArrowRight') {
+  //       //   handle1SecondIncrementDecrement(true, selectedTooltip);
+  //       // } else if (e.key === 'ArrowLeft') {
+  //       //   handle1SecondIncrementDecrement(false, selectedTooltip);
+  //       // }
+  //     }
 
-      if (e.key == ' ' || e.code == 'Space' || e.keyCode == 32) {
-        if (videoRef.current) {
-          if (videoRef.current.paused) {
-            videoRef.current.play();
-          } else {
-            videoRef.current.pause();
-          }
-        }
-      }
-    });
-    return () => {
-      window.removeEventListener('dragstart', preventDefault);
-      window.removeEventListener('dragover', preventDefault);
-    };
-  }, [selectedTooltip, videoRef]);
+  //     if (e.key == ' ' || e.code == 'Space' || e.keyCode == 32) {
+  //       if (videoRef.current) {
+  //         if (videoRef.current.paused) {
+  //           videoRef.current.play();
+  //         } else {
+  //           videoRef.current.pause();
+  //         }
+  //       }
+  //     }
+  //   });
+  //   return () => {
+  //     window.removeEventListener('dragstart', preventDefault);
+  //     window.removeEventListener('dragover', preventDefault);
+  //   };
+  // }, [selectedTooltip, videoRef]);
 
   const getMarkerPosition = (time: number) => {
     if (videoRef.current && videoRef.current.duration) {
@@ -102,7 +102,7 @@ const TrimmControls = ({
   };
   return (
     <div
-      className={`absolute h-[calc(100%-20px)] w-[10px] top-6`}
+      className={`absolute h-[calc(100%-20px)] w-[10px] top-6 z-40`}
       style={{
         left: `${getMarkerPosition(
           marker === 'start' ? startTime.displayTime : endTime.displayTime

--- a/packages/app/app/studio/[organization]/clips/[stageId]/Timeline/index.tsx
+++ b/packages/app/app/studio/[organization]/clips/[stageId]/Timeline/index.tsx
@@ -27,6 +27,7 @@ const Timeline = () => {
     setEndTime,
     startTime,
     endTime,
+    setCurrentTime,
   } = useClipContext();
 
   const timelineRef = useRef<HTMLDivElement>(null);
@@ -102,6 +103,17 @@ const Timeline = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentTime, handleMouseDown, playbackStatus, startTime, endTime]);
 
+  const handleTimelineClick = (event: React.MouseEvent) => {
+    if (videoRef.current) {
+      const timelineElement = event.currentTarget as HTMLElement;
+      const timelineRect = timelineElement.getBoundingClientRect();
+      const relativeClickX = event.clientX - timelineRect.left;
+      const clickTime = (relativeClickX / timelineWidth) * maxLength;
+      videoRef.current.currentTime = clickTime;
+      setCurrentTime(clickTime);
+    }
+  };
+
   if (!maxLength || !timelineWidth || !videoRef.current)
     return (
       // loading state
@@ -129,7 +141,7 @@ const Timeline = () => {
             return (
               <div
                 key={marker._id}
-                className={`absolute h-[20px] border bg-opacity-20 rounded`}
+                className={`absolute h-[20px] border bg-opacity-20 rounded z-[21]`}
                 onClick={() => handleMarkerClick(marker)}
                 style={{
                   backgroundColor: marker.color,
@@ -149,11 +161,16 @@ const Timeline = () => {
             );
           })}
         <Playhead maxLength={maxLength} timelineWidth={timelineWidth} />
-        <TimelineDrawing
-          maxLength={maxLength}
-          timelineWidth={timelineWidth}
-          scale={pixelsPerSecond}
-        />
+        <div
+          onClick={handleTimelineClick}
+          className="absolute top-0 left-0 w-full h-full z-[20]"
+        >
+          <TimelineDrawing
+            maxLength={maxLength}
+            timelineWidth={timelineWidth}
+            scale={pixelsPerSecond}
+          />
+        </div>
         <TrimmControls
           {...{
             handleMouseDown: (e: React.MouseEvent) =>

--- a/packages/app/app/studio/[organization]/clips/[stageId]/topBar/CreateClipButton.tsx
+++ b/packages/app/app/studio/[organization]/clips/[stageId]/topBar/CreateClipButton.tsx
@@ -57,6 +57,7 @@ const CreateClipButton = ({
     endTime,
     selectedMarkerId,
     setSelectedMarkerId,
+    videoRef,
   } = useClipContext();
   // const [selectedMarkerId, setSelectedMarkerId] = useState('');
   const [isCreateClip, setIsCreateClip] = useState(false);
@@ -84,6 +85,13 @@ const CreateClipButton = ({
     getStage();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);
+
+  const handlePreview = () => {
+    if (videoRef.current) {
+      videoRef.current.currentTime = startTime.displayTime;
+      videoRef.current.play();
+    }
+  };
 
   const selectedMarker = markers.find(
     (marker) => marker._id === selectedMarkerId
@@ -332,6 +340,13 @@ const CreateClipButton = ({
                 onClick={() => setIsCreatingClip(false)}
               >
                 Cancel
+              </Button>
+              <Button
+                variant={'secondary'}
+                onClick={handlePreview}
+                type="button"
+              >
+                Preview
               </Button>
               <Button
                 className="w-3/4"


### PR DESCRIPTION
# Pull Request Template

## Title
Clipping page UX changes on the timeline.

## Type of Change
- [ ] New feature ✨
- [ ] Bug fix 🐛
- [ ] Documentation update 📝
- [ ] Refactoring ♻️
- [ ] Hotfix 🚑️
- [x ] UI/UX improvement 💄

## Description
- You can now click on the timeline to move the playhead. 
- You can now drag the slider and the playhead won't follow. 
- When creating a clip, you can click on preview to play at the very start of the clip slider.
- Commented some duplicated code. 
-
## Testing
[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

## Impact
- Rearranged some z indexes on the timeline.

## Additional Information
[Any additional information that reviewers should be aware of.]

## Checklist
- [ x] My code adheres to the coding and style guidelines of the project.
- [ x] I have performed a self-review of my own code.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have made corresponding changes to the documentation.
- [ x] My changes generate no new warnings 
