### PR TITLE
🐛 Fixed m3u8 links

### DIFF
--- a/packages/app/lib/utils/utils.ts
+++ b/packages/app/lib/utils/utils.ts
@@ -400,7 +400,8 @@ export const getLiveStageSrcValue = ({
   playbackId?: string;
   recordingId?: string;
 }) => {
-  return `https://link.storjshare.io/raw/juixm77hfsmhyslrxtycnqfmnlfq/catalyst-recordings-com/hls/${playbackId}/${recordingId}/output.m3u8`;
+  return `https://recordings-cdn-s.lp-playback.studio/hls/${playbackId}/${recordingId}/output.m3u8`;
+  //return `https://link.storjshare.io/raw/juixm77hfsmhyslrxtycnqfmnlfq/catalyst-recordings-com/hls/${playbackId}/${recordingId}/output.m3u8`;
 };
 
 export const getTokenExpiration = (token: string): number | null => {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix 🐛

## Description
During devcon we discovered that Livepeer is now using a new storage provider for m3u8 files, which results in a new link format for retrieving them.

## Additional Information

  `return https://link.storjshare.io/raw/juixm77hfsmhyslrxtycnqfmnlfq/catalyst-recordings-com/hls/${playbackId}/${recordingId}/output.m3u8;`
  
  is now
  
  `return https://recordings-cdn-s.lp-playback.studio/hls/${playbackId}/${recordingId}/output.m3u8;`