### PR TITLE
♻️ Refactor: Simplify Thumbnail component and remove blur placeholder

### DIFF
--- a/packages/app/components/misc/VideoCard/thumbnail.tsx
+++ b/packages/app/components/misc/VideoCard/thumbnail.tsx
@@ -1,50 +1,47 @@
-'use client';
-import Image from 'next/image';
-import { useEffect, useState } from 'react';
-import DefaultThumbnail from '@/lib/svg/DefaultThumbnail';
-import { AspectRatio } from '@/components/ui/aspect-ratio';
+"use client";
+
+import Image from "next/image";
+import DefaultThumbnail from "@/lib/svg/DefaultThumbnail";
+import { AspectRatio } from "@/components/ui/aspect-ratio";
 
 type ThumbnailProps = {
-  imageUrl?: string;
-  fallBack?: string;
+	imageUrl?: string;
+	fallBack?: string;
 };
 
 export default function Thumbnail({ imageUrl, fallBack }: ThumbnailProps) {
-  const srcUrl = imageUrl || fallBack;
+	const srcUrl = imageUrl || fallBack;
 
-  if (!srcUrl) {
-    return (
-      <AspectRatio
-        ratio={16 / 9}
-        className="flex w-full items-center justify-center"
-      >
-        <DefaultThumbnail />
-      </AspectRatio>
-    );
-  }
+	if (!srcUrl) {
+		return (
+			<AspectRatio
+				ratio={16 / 9}
+				className="flex justify-center items-center w-full"
+			>
+				<DefaultThumbnail />
+			</AspectRatio>
+		);
+	}
 
-  return (
-    <div className="relative aspect-video w-full z-1">
-      <Image
-        placeholder="blur"
-        blurDataURL={srcUrl}
-        loading="lazy"
-        decoding="async"
-        data-nimg="fill"
-        className="rounded-xl z-1"
-        alt="Session image"
-        quality={100}
-        src={srcUrl}
-        fill
-        sizes="(max-width: 768px) 100%, (max-width: 1200px) 50%, 33%"
-        style={{
-          position: 'absolute',
-          height: '100%',
-          width: '100%',
-          inset: 0,
-          objectFit: 'cover',
-        }}
-      />
-    </div>
-  );
+	return (
+		<div className="relative w-full aspect-video z-1">
+			<Image
+				loading="lazy"
+				decoding="async"
+				data-nimg="fill"
+				className="rounded-xl z-1"
+				alt="Session image"
+				src={srcUrl}
+				fill
+				sizes="(max-width: 768px) 100%, (max-width: 1200px) 50%, 33%"
+				style={{
+					position: "absolute",
+					height: "100%",
+					width: "100%",
+					inset: 0,
+					objectFit: "cover",
+				}}
+			/>
+		</div>
+	);
 }


### PR DESCRIPTION
## Type of Change
- [ ] New feature ✨
- [ ] Bug fix 🐛
- [ ] Documentation update 📝
- [x] Refactoring ♻️
- [ ] Hotfix 🚑️
- [ ] UI/UX improvement 💄 *(Potentially, if blur removal is considered a UX change)*

---
## Description
This pull request refactors the `Thumbnail` component (`packages/app/components/misc/VideoCard/thumbnail.tsx`) to simplify its implementation and address previous discussions regarding `next/image` properties.

The key changes include:
- **Removal of Blur Placeholder:** The `placeholder="blur"` and `blurDataURL={srcUrl}` props have been removed from the `next/image` component. The `blurDataURL` was previously misconfigured, and this change removes the blur-up placeholder effect.
- **Removal of Explicit Quality Setting:** The `quality={100}` prop has been removed. The `next/image` component will now use its default quality settings or those configured globally in `next.config.js`.
- **Removed Unused Hooks:** `useEffect` and `useState` imports and any associated logic have been removed, as they are no longer needed after removing the placeholder effects.

The component continues to display the provided `imageUrl` (or `fallBack`), and renders a `DefaultThumbnail` if no image URL is available. Other `next/image` props for lazy loading, responsive sizing (`fill`, `sizes`), and styling remain.

---
## Testing
- [ ] Manually verified that thumbnails render correctly with and without an `imageUrl`.
- [ ] Checked that the `DefaultThumbnail` displays when no `imageUrl` or `fallBack` is provided.
- [ ] Observed image loading behavior to confirm the absence of the blur-up effect.
- [ ] Verified in browser developer tools that images are still being optimized by `next/image` as expected (e.g., served in WebP format if browser supports it, appropriate sizes based on `sizes` prop).

---
## Impact
- **Performance/UX:** Removing the misconfigured `blurDataURL` may slightly improve initial load performance for the image component. Users will no longer see the blur-up effect.
- **Image Quality:** Image quality will now be determined by Next.js default optimization settings or global configurations, rather than being forced to `quality={100}`. This could lead to better file size vs. quality balance.
- **Code Simplicity:** The `Thumbnail` component is now simpler due to the removal of placeholder-related state and props.

---
## Additional Information
This change aligns with previous discussions on optimizing image handling and correctly utilizing `next/image` features. The removal of `quality={100}` is intended to leverage Next.js's own optimization defaults which are generally well-balanced.