### PR TITLE
feat: Add Random Sorting Option for Archived Videos

### DIFF
--- a/packages/app/app/[organization]/livestream/page.tsx
+++ b/packages/app/app/[organization]/livestream/page.tsx
@@ -71,6 +71,7 @@ export default async function Livestream({
 				<div className="md:hidden">
 					<Suspense fallback={<ArchiveVideoSkeleton />}>
 						<ArchiveVideos
+							sortBy="random"
 							organizationId={organization}
 							organizationSlug={organization}
 							gridLength={4}
@@ -80,6 +81,7 @@ export default async function Livestream({
 				<div className="hidden md:block">
 					<Suspense fallback={<ArchiveVideoSkeleton />}>
 						<ArchiveVideos
+							sortBy="random"
 							organizationId={organization}
 							organizationSlug={organization}
 							gridLength={8}

--- a/packages/app/app/[organization]/videos/components/ArchiveVideos.tsx
+++ b/packages/app/app/[organization]/videos/components/ArchiveVideos.tsx
@@ -10,6 +10,7 @@ interface ArchiveVideosProps {
 	searchQuery?: string;
 	page?: number;
 	gridLength: number;
+	sortBy?: "default" | "random";
 }
 
 const ArchiveVideos = async ({
@@ -17,8 +18,9 @@ const ArchiveVideos = async ({
 	searchQuery,
 	page,
 	gridLength = 10,
+	sortBy = "default",
 }: ArchiveVideosProps) => {
-	const { sessions, pagination } = await fetchAllSessions({
+	let { sessions, pagination } = await fetchAllSessions({
 		organizationId,
 		limit: gridLength,
 		onlyVideos: true,
@@ -27,7 +29,9 @@ const ArchiveVideos = async ({
 		page,
 	});
 
-	let shuffledSessions = shuffleArray(sessions);
+	if (sortBy === "random") {
+		sessions = shuffleArray(sessions);
+	}
 
 	if (!searchQuery && sessions.length === 0) {
 		return (
@@ -51,7 +55,7 @@ const ArchiveVideos = async ({
 
 	return (
 		<>
-			<VideoGrid videos={shuffledSessions} />
+			<VideoGrid videos={sessions} />
 			{page && pagination.totalPages > 1 && <Pagination {...pagination} />}
 		</>
 	);

--- a/packages/app/app/[organization]/watch/page.tsx
+++ b/packages/app/app/[organization]/watch/page.tsx
@@ -95,6 +95,7 @@ export default async function Watch({
 					<div className="md:hidden">
 						<Suspense fallback={<ArchiveVideoSkeleton />}>
 							<ArchiveVideos
+								sortBy="random"
 								organizationId={params.organization}
 								organizationSlug={params.organization}
 								gridLength={4}
@@ -104,6 +105,7 @@ export default async function Watch({
 					<div className="hidden md:block">
 						<Suspense fallback={<ArchiveVideoSkeleton />}>
 							<ArchiveVideos
+								sortBy="random"
 								organizationId={params.organization}
 								organizationSlug={params.organization}
 								gridLength={8}


### PR DESCRIPTION
## Type of Change
- [x] New feature ✨
- [ ] Bug fix 🐛
- [ ] Documentation update 📝
- [ ] Refactoring ♻️
- [ ] Hotfix 🚑️
- [ ] UI/UX improvement 💄

## Description
This pull request introduces a new feature to control the display order of videos in the `ArchiveVideos` component. A `sortBy` prop has been added, which allows videos to be displayed in a randomized order.

Key changes include:

* **`ArchiveVideos.tsx`**:
    * The component now accepts a `sortBy` prop, which can be `"default"` or `"random"`.
    * If `sortBy` is set to `"random"`, the fetched sessions are passed through the `shuffleArray` utility before being rendered.
    * The default behavior remains chronological (as returned by `fetchAllSessions`).

* **`livestream/page.tsx` & `watch/page.tsx`**:
    * The `ArchiveVideos` components on the Livestream and Watch pages now use `sortBy="random"` to display a random selection of other videos, enhancing content discovery for viewers.

This change makes the `ArchiveVideos` component more flexible and improves its utility as a content discovery tool on high-traffic pages.

## Impact
* **Enhanced Content Discovery**: Randomizing the order of videos on key pages can increase user engagement by surfacing content they might not have seen otherwise.
* **Component Reusability**: The `ArchiveVideos` component is now more versatile with the added sorting option.
* There are no new dependencies or breaking changes.
